### PR TITLE
chore: configure Ruff with lint rules and apply fixes (BEC-5)

### DIFF
--- a/main.py
+++ b/main.py
@@ -4,8 +4,6 @@ Requires a .env file with PRIMARY_USER and PRIMARY_PASSWORD.
 """
 
 import matriz_client as primary
-import time
-
 
 # usuario: api_bbsa
 # contraseña: ktMqm7sD_

--- a/main_ws.py
+++ b/main_ws.py
@@ -9,8 +9,8 @@ then sends an order and waits for messages.
 import signal
 import time
 
-from main import ACCOUNT_1
 import matriz_client as primary
+from main import ACCOUNT_1
 
 ACCOUNT = "xprimary"
 SYMBOL = "MERV - XMEV - AL30 - 24HS"
@@ -58,7 +58,7 @@ def main() -> None:
     signal.signal(signal.SIGINT, stop)
 
     # 1. Connect
-    print(f"Connecting to WebSocket...")
+    print("Connecting to WebSocket...")
     primary.ws_connect(
         on_message=on_message,
         on_error=on_error,

--- a/matriz_client/client.py
+++ b/matriz_client/client.py
@@ -13,9 +13,7 @@ from .exceptions import AuthenticationError, PrimaryAPIError
 load_dotenv()
 
 # -- Module-level state --
-_base_url: str = os.getenv(
-    "PRIMARY_BASE_URL", "https://api.remarkets.primary.com.ar"
-).rstrip("/")
+_base_url: str = os.getenv("PRIMARY_BASE_URL", "https://api.remarkets.primary.com.ar").rstrip("/")
 _user: str = os.getenv("PRIMARY_USER", "")
 _password: str = os.getenv("PRIMARY_PASSWORD", "")
 _token: str | None = None
@@ -41,9 +39,7 @@ def login() -> str:
     """Authenticate and store the token. Returns the token string."""
     global _token, _token_ts
     if not _user or not _password:
-        raise AuthenticationError(
-            "ERROR", "PRIMARY_USER and PRIMARY_PASSWORD must be set"
-        )
+        raise AuthenticationError("ERROR", "PRIMARY_USER and PRIMARY_PASSWORD must be set")
 
     resp = _session.post(
         f"{_base_url}/auth/getToken",
@@ -73,15 +69,11 @@ def _request(
 ) -> dict[str, Any]:
     url = f"{_base_url}{path}"
     if auth_basic:
-        resp = _session.request(
-            method, url, params=params, auth=HTTPBasicAuth(*auth_basic)
-        )
+        resp = _session.request(method, url, params=params, auth=HTTPBasicAuth(*auth_basic))
     else:
         _ensure_token()
         assert _token is not None
-        resp = _session.request(
-            method, url, params=params, headers={"X-Auth-Token": _token}
-        )
+        resp = _session.request(method, url, params=params, headers={"X-Auth-Token": _token})
 
     resp.raise_for_status()
     data: dict[str, Any] = resp.json()
@@ -130,9 +122,7 @@ def get_instruments_details() -> list[dict[str, Any]]:
 
 def get_instrument_detail(symbol: str, market_id: str = "ROFX") -> dict[str, Any]:
     """Return detail for a single instrument."""
-    return _get("/rest/instruments/detail", symbol=symbol, marketId=market_id)[
-        "instrument"
-    ]
+    return _get("/rest/instruments/detail", symbol=symbol, marketId=market_id)["instrument"]
 
 
 def get_instruments_by_cfi(cfi_code: str) -> list[dict[str, Any]]:
@@ -140,13 +130,11 @@ def get_instruments_by_cfi(cfi_code: str) -> list[dict[str, Any]]:
     return _get("/rest/instruments/byCFICode", CFICode=cfi_code)["instruments"]
 
 
-def get_instruments_by_segment(
-    segment_id: str, market_id: str = "ROFX"
-) -> list[dict[str, Any]]:
+def get_instruments_by_segment(segment_id: str, market_id: str = "ROFX") -> list[dict[str, Any]]:
     """Return instruments in a given segment."""
-    return _get(
-        "/rest/instruments/bySegment", MarketSegmentID=segment_id, MarketID=market_id
-    )["instruments"]
+    return _get("/rest/instruments/bySegment", MarketSegmentID=segment_id, MarketID=market_id)[
+        "instruments"
+    ]
 
 
 # ------------------------------------------------------------------
@@ -191,9 +179,7 @@ def new_order(
     return _get("/rest/order/newSingleOrder", **params)["order"]
 
 
-def replace_order(
-    cl_ord_id: str, proprietary: str, qty: int, price: float
-) -> dict[str, Any]:
+def replace_order(cl_ord_id: str, proprietary: str, qty: int, price: float) -> dict[str, Any]:
     """Replace (modify) an existing order by clOrdId."""
     return _get(
         "/rest/order/replaceById",
@@ -298,13 +284,9 @@ def get_positions(account_name: str) -> dict[str, Any]:
 
 def get_detailed_positions(account_name: str) -> dict[str, Any]:
     """Get detailed positions for an account (Risk API)."""
-    return _request(
-        "GET", f"/rest/risk/detailedPosition/{account_name}", auth_basic=_risk_auth()
-    )
+    return _request("GET", f"/rest/risk/detailedPosition/{account_name}", auth_basic=_risk_auth())
 
 
 def get_account_report(account_name: str) -> dict[str, Any]:
     """Get account report (Risk API)."""
-    return _request(
-        "GET", f"/rest/risk/accountReport/{account_name}", auth_basic=_risk_auth()
-    )
+    return _request("GET", f"/rest/risk/accountReport/{account_name}", auth_basic=_risk_auth())

--- a/matriz_client/ws_client.py
+++ b/matriz_client/ws_client.py
@@ -2,7 +2,8 @@ from __future__ import annotations
 
 import json
 import threading
-from typing import Any, Callable
+from collections.abc import Callable
+from typing import Any
 
 import websocket
 
@@ -109,9 +110,7 @@ def ws_connect(
     _ws_thread = threading.Thread(target=_ws.run_forever, daemon=True)
     _ws_thread.start()
     if not _connected.wait(timeout=timeout):
-        raise TimeoutError(
-            f"WebSocket connection to {url} timed out after {timeout}s"
-        )
+        raise TimeoutError(f"WebSocket connection to {url} timed out after {timeout}s")
 
 
 def ws_disconnect() -> None:
@@ -159,9 +158,7 @@ def ws_subscribe_market_data(
         "type": "smd",
         "level": 1,
         "entries": entries,
-        "products": [
-            {"symbol": s, "marketId": market_id} for s in symbols
-        ],
+        "products": [{"symbol": s, "marketId": market_id} for s in symbols],
         "depth": depth,
     }
     _send(msg)
@@ -266,8 +263,10 @@ def ws_cancel_order(client_id: str, proprietary: str) -> None:
         client_id: The clOrdId of the order to cancel.
         proprietary: The proprietary identifier (e.g. "PBCP").
     """
-    _send({
-        "type": "co",
-        "clientId": client_id,
-        "proprietary": proprietary,
-    })
+    _send(
+        {
+            "type": "co",
+            "clientId": client_id,
+            "proprietary": proprietary,
+        }
+    )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,3 +14,27 @@ dependencies = [
 dev = [
     "ruff>=0.11.0",
 ]
+
+[tool.ruff]
+line-length = 100
+target-version = "py312"
+extend-exclude = [".venv", "matriz-vault"]
+
+[tool.ruff.lint]
+select = [
+    "E",    # pycodestyle errors
+    "W",    # pycodestyle warnings
+    "F",    # pyflakes
+    "I",    # isort
+    "B",    # flake8-bugbear
+    "UP",   # pyupgrade
+    "SIM",  # flake8-simplify
+    "N",    # pep8-naming
+]
+ignore = [
+    "E501",  # line too long (handled by formatter)
+]
+
+[tool.ruff.format]
+quote-style = "double"
+indent-style = "space"

--- a/utils/time_cached.py
+++ b/utils/time_cached.py
@@ -3,9 +3,11 @@ Time-based caching decorator that caches function results based on parameters an
 Only calls the function if parameters are new or specified seconds have passed.
 """
 
-import time
 import functools
-from typing import Any, Callable, Dict, Tuple, TypeVar, cast
+import time
+from collections.abc import Callable
+from typing import Any, TypeVar, cast
+
 from typing_extensions import ParamSpec
 
 # Type variables for preserving function signatures
@@ -41,7 +43,7 @@ def time_cached(seconds: float, *, debug: bool = False) -> Callable[[F], F]:
     def decorator(func: F) -> F:
         # Dictionary to store cached results and timestamps
         # Key: hash of arguments, Value: (result, timestamp)
-        cache: Dict[int, Tuple[Any, float]] = {}
+        cache: dict[int, tuple[Any, float]] = {}
 
         @functools.wraps(func)
         def wrapper(*args: Any, **kwargs: Any) -> Any:
@@ -60,9 +62,7 @@ def time_cached(seconds: float, *, debug: bool = False) -> Callable[[F], F]:
                 # If the cached result is still fresh (within the time limit)
                 if current_time - cached_time < seconds:
                     if debug:
-                        print(
-                            f"Cache hit for {func.__name__} with args={args}, kwargs={kwargs}"
-                        )
+                        print(f"Cache hit for {func.__name__} with args={args}, kwargs={kwargs}")
                     return cached_result
                 else:
                     if debug:


### PR DESCRIPTION
## Summary

- Configurar Ruff en `pyproject.toml` con reglas para pycodestyle, pyflakes, isort, bugbear, pyupgrade, simplify y pep8-naming
- `line-length=100`, `target-version=py312`, excluir `.venv` y `matriz-vault`
- Aplicar auto-fixes sobre el código existente: ordenar imports, remover imports no usados, actualizar typing a sintaxis moderna (`Dict`→`dict`, `Callable` desde `collections.abc`), sacar f-strings sin placeholders
- Reformatear todos los archivos a line-length=100

## Linear Issue

BEC-5 — https://linear.app/gravity-code/issue/BEC-5/configurar-ruff-linter-formatter

## Test plan

- [x] `uv run ruff check .` pasa sin errores
- [x] `uv run ruff format --check .` pasa sin cambios pendientes
- [x] CI de GitHub Actions pasa en este PR

## Notes

Los cambios en `matriz_client/client.py` son puramente de formato (líneas consolidadas al pasar de 88 a 100 chars). No hay cambios funcionales en ningún módulo.