### PR TITLE
test: add pytest suite (BEC-6)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,8 +12,13 @@ dependencies = [
 
 [dependency-groups]
 dev = [
+    "pytest>=8.3.0",
     "ruff>=0.11.0",
 ]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+addopts = "-ra"
 
 [tool.ruff]
 line-length = 100

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import time
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from matriz_client import client as _client
+
+
+@pytest.fixture
+def reset_client_state(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Reset module-level auth state and inject dummy credentials."""
+    monkeypatch.setattr(_client, "_token", "test-token")
+    monkeypatch.setattr(_client, "_token_ts", time.time())
+    monkeypatch.setattr(_client, "_user", "test-user")
+    monkeypatch.setattr(_client, "_password", "test-pass")
+    monkeypatch.setattr(_client, "_base_url", "https://api.test")
+
+
+@pytest.fixture
+def mock_session(monkeypatch: pytest.MonkeyPatch) -> MagicMock:
+    """Replace the requests session with a MagicMock."""
+    mock = MagicMock()
+    monkeypatch.setattr(_client, "_session", mock)
+    return mock
+
+
+def build_response(payload: dict[str, Any], headers: dict[str, str] | None = None) -> MagicMock:
+    """Build a MagicMock response with json() and headers."""
+    response = MagicMock()
+    response.json.return_value = payload
+    response.headers = headers or {}
+    response.raise_for_status.return_value = None
+    return response

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,0 +1,195 @@
+from __future__ import annotations
+
+import time
+from unittest.mock import MagicMock
+
+import pytest
+
+from matriz_client import client as _client
+from matriz_client.exceptions import AuthenticationError, PrimaryAPIError
+from tests.conftest import build_response
+
+# ------------------------------------------------------------------
+# Auth
+# ------------------------------------------------------------------
+
+
+def test_login_requires_credentials(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(_client, "_user", "")
+    monkeypatch.setattr(_client, "_password", "")
+    monkeypatch.setattr(_client, "_token", None)
+    with pytest.raises(AuthenticationError):
+        _client.login()
+
+
+def test_login_stores_token_from_header(
+    monkeypatch: pytest.MonkeyPatch, mock_session: MagicMock
+) -> None:
+    monkeypatch.setattr(_client, "_user", "u")
+    monkeypatch.setattr(_client, "_password", "p")
+    monkeypatch.setattr(_client, "_token", None)
+    monkeypatch.setattr(_client, "_token_ts", 0.0)
+    mock_session.post.return_value = build_response({}, headers={"X-Auth-Token": "tkn-123"})
+
+    token = _client.login()
+
+    assert token == "tkn-123"
+    assert _client._token == "tkn-123"
+    assert _client._token_ts > 0
+
+
+def test_login_raises_when_header_missing(
+    monkeypatch: pytest.MonkeyPatch, mock_session: MagicMock
+) -> None:
+    monkeypatch.setattr(_client, "_user", "u")
+    monkeypatch.setattr(_client, "_password", "p")
+    monkeypatch.setattr(_client, "_token", None)
+    mock_session.post.return_value = build_response({}, headers={})
+    with pytest.raises(AuthenticationError):
+        _client.login()
+
+
+def test_ensure_token_skips_when_fresh(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(_client, "_token", "fresh")
+    monkeypatch.setattr(_client, "_token_ts", time.time())
+    called = {"n": 0}
+
+    def fake_login() -> str:
+        called["n"] += 1
+        return "new"
+
+    monkeypatch.setattr(_client, "login", fake_login)
+    _client._ensure_token()
+    assert called["n"] == 0
+
+
+def test_ensure_token_refreshes_when_stale(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(_client, "_token", "old")
+    monkeypatch.setattr(_client, "_token_ts", time.time() - (24 * 60 * 60))
+    called = {"n": 0}
+
+    def fake_login() -> str:
+        called["n"] += 1
+        return "new"
+
+    monkeypatch.setattr(_client, "login", fake_login)
+    _client._ensure_token()
+    assert called["n"] == 1
+
+
+# ------------------------------------------------------------------
+# Request plumbing
+# ------------------------------------------------------------------
+
+
+def test_request_raises_on_error_payload(reset_client_state: None, mock_session: MagicMock) -> None:
+    mock_session.request.return_value = build_response(
+        {"status": "ERROR", "description": "bad symbol", "message": "x"}
+    )
+    with pytest.raises(PrimaryAPIError) as exc:
+        _client._request("GET", "/rest/anything")
+    assert exc.value.description == "bad symbol"
+
+
+def test_request_sends_auth_header(reset_client_state: None, mock_session: MagicMock) -> None:
+    mock_session.request.return_value = build_response({"status": "OK"})
+    _client._request("GET", "/rest/anything", params={"symbol": "DLR/DIC23"})
+    _, kwargs = mock_session.request.call_args
+    assert kwargs["headers"] == {"X-Auth-Token": "test-token"}
+    assert kwargs["params"] == {"symbol": "DLR/DIC23"}
+
+
+def test_request_with_basic_auth_skips_token(
+    reset_client_state: None, mock_session: MagicMock
+) -> None:
+    mock_session.request.return_value = build_response({"status": "OK"})
+    _client._request("GET", "/rest/risk/x", auth_basic=("u", "p"))
+    _, kwargs = mock_session.request.call_args
+    assert "headers" not in kwargs
+    assert kwargs["auth"].username == "u"
+    assert kwargs["auth"].password == "p"
+
+
+def test_get_filters_none_params(reset_client_state: None, mock_session: MagicMock) -> None:
+    mock_session.request.return_value = build_response({"status": "OK"})
+    _client._get("/rest/x", symbol="ABC", foo=None, bar=1)
+    _, kwargs = mock_session.request.call_args
+    assert kwargs["params"] == {"symbol": "ABC", "bar": 1}
+
+
+# ------------------------------------------------------------------
+# Endpoint wrappers
+# ------------------------------------------------------------------
+
+
+def test_get_segments(reset_client_state: None, mock_session: MagicMock) -> None:
+    mock_session.request.return_value = build_response(
+        {"status": "OK", "segments": [{"marketSegmentId": "DDF"}]}
+    )
+    assert _client.get_segments() == [{"marketSegmentId": "DDF"}]
+    args, _ = mock_session.request.call_args
+    assert args[1].endswith("/rest/segment/all")
+
+
+def test_get_instrument_detail_passes_symbol(
+    reset_client_state: None, mock_session: MagicMock
+) -> None:
+    mock_session.request.return_value = build_response(
+        {"status": "OK", "instrument": {"symbol": "DLR/DIC23"}}
+    )
+    result = _client.get_instrument_detail("DLR/DIC23")
+    assert result == {"symbol": "DLR/DIC23"}
+    _, kwargs = mock_session.request.call_args
+    assert kwargs["params"] == {"symbol": "DLR/DIC23", "marketId": "ROFX"}
+
+
+def test_new_order_builds_params(reset_client_state: None, mock_session: MagicMock) -> None:
+    mock_session.request.return_value = build_response(
+        {"status": "OK", "order": {"clientId": "abc", "proprietary": "PBCP"}}
+    )
+    _client.new_order(
+        symbol="DLR/DIC23",
+        side="BUY",
+        qty=10,
+        account="ACC1",
+        price=123.5,
+    )
+    _, kwargs = mock_session.request.call_args
+    params = kwargs["params"]
+    assert params["symbol"] == "DLR/DIC23"
+    assert params["side"] == "BUY"
+    assert params["orderQty"] == 10
+    assert params["account"] == "ACC1"
+    assert params["price"] == 123.5
+    assert params["ordType"] == "LIMIT"
+    assert params["timeInForce"] == "DAY"
+    assert params["cancelPrevious"] == "False"
+    assert params["iceberg"] == "False"
+
+
+def test_new_order_omits_optional_fields(reset_client_state: None, mock_session: MagicMock) -> None:
+    mock_session.request.return_value = build_response({"status": "OK", "order": {}})
+    _client.new_order(symbol="S", side="SELL", qty=1, account="A")
+    _, kwargs = mock_session.request.call_args
+    params = kwargs["params"]
+    assert "price" not in params
+    assert "displayQty" not in params
+    assert "expireDate" not in params
+
+
+def test_get_market_data_defaults(reset_client_state: None, mock_session: MagicMock) -> None:
+    mock_session.request.return_value = build_response({"status": "OK", "marketData": {"LA": {}}})
+    _client.get_market_data("DLR/DIC23")
+    _, kwargs = mock_session.request.call_args
+    assert kwargs["params"]["entries"] == "BI,OF,LA,OP,CL,SE,OI"
+    assert kwargs["params"]["marketId"] == "ROFX"
+    assert "depth" not in kwargs["params"]
+
+
+def test_get_positions_uses_basic_auth(reset_client_state: None, mock_session: MagicMock) -> None:
+    mock_session.request.return_value = build_response({"status": "OK", "positions": []})
+    _client.get_positions("ACC1")
+    args, kwargs = mock_session.request.call_args
+    assert args[1].endswith("/rest/risk/position/getPositions/ACC1")
+    assert "headers" not in kwargs
+    assert kwargs["auth"] is not None

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+import pytest
+
+from matriz_client.exceptions import AuthenticationError, PrimaryAPIError
+
+
+def test_primary_api_error_uses_description_first() -> None:
+    err = PrimaryAPIError("ERROR", description="invalid symbol", message="generic")
+    assert str(err) == "invalid symbol"
+    assert err.status == "ERROR"
+    assert err.description == "invalid symbol"
+    assert err.api_message == "generic"
+
+
+def test_primary_api_error_falls_back_to_message() -> None:
+    err = PrimaryAPIError("ERROR", message="something broke")
+    assert str(err) == "something broke"
+
+
+def test_primary_api_error_falls_back_to_status() -> None:
+    err = PrimaryAPIError("ERROR")
+    assert str(err) == "ERROR"
+
+
+def test_authentication_error_is_primary_api_error() -> None:
+    err = AuthenticationError("ERROR", description="bad credentials")
+    assert isinstance(err, PrimaryAPIError)
+    with pytest.raises(AuthenticationError):
+        raise err

--- a/tests/test_ws_client.py
+++ b/tests/test_ws_client.py
@@ -1,0 +1,146 @@
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from matriz_client import client as _rest
+from matriz_client import ws_client as _ws
+
+
+@pytest.fixture
+def capture_send(monkeypatch: pytest.MonkeyPatch) -> list[dict[str, Any]]:
+    """Replace _send with a capturing stub. Returns the list of sent messages."""
+    sent: list[dict[str, Any]] = []
+    monkeypatch.setattr(_ws, "_send", lambda msg: sent.append(msg))
+    return sent
+
+
+def test_ws_url_converts_https(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(_rest, "_base_url", "https://api.remarkets.primary.com.ar")
+    assert _ws._ws_url() == "wss://api.remarkets.primary.com.ar"
+
+
+def test_ws_url_converts_http(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(_rest, "_base_url", "http://localhost:8080")
+    assert _ws._ws_url() == "ws://localhost:8080"
+
+
+def test_send_without_connection_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(_ws, "_ws", None)
+    _ws._connected.clear()
+    with pytest.raises(RuntimeError):
+        _ws._send({"type": "x"})
+
+
+def test_send_without_connected_event_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(_ws, "_ws", MagicMock())
+    _ws._connected.clear()
+    with pytest.raises(RuntimeError):
+        _ws._send({"type": "x"})
+
+
+def test_send_forwards_json(monkeypatch: pytest.MonkeyPatch) -> None:
+    fake_ws = MagicMock()
+    monkeypatch.setattr(_ws, "_ws", fake_ws)
+    _ws._connected.set()
+    try:
+        _ws._send({"type": "os"})
+    finally:
+        _ws._connected.clear()
+    sent_raw = fake_ws.send.call_args.args[0]
+    assert sent_raw == '{"type": "os"}'
+
+
+def test_is_connected_reflects_event(monkeypatch: pytest.MonkeyPatch) -> None:
+    _ws._connected.clear()
+    assert _ws.ws_is_connected() is False
+    _ws._connected.set()
+    try:
+        assert _ws.ws_is_connected() is True
+    finally:
+        _ws._connected.clear()
+
+
+def test_subscribe_market_data_default_entries(capture_send: list[dict[str, Any]]) -> None:
+    _ws.ws_subscribe_market_data(["DLR/DIC23"])
+    assert capture_send == [
+        {
+            "type": "smd",
+            "level": 1,
+            "entries": ["BI", "OF", "LA", "OP", "CL", "SE", "OI"],
+            "products": [{"symbol": "DLR/DIC23", "marketId": "ROFX"}],
+            "depth": 1,
+        }
+    ]
+
+
+def test_subscribe_market_data_custom(capture_send: list[dict[str, Any]]) -> None:
+    _ws.ws_subscribe_market_data(["A", "B"], entries=["BI", "OF"], market_id="MERV", depth=5)
+    msg = capture_send[0]
+    assert msg["entries"] == ["BI", "OF"]
+    assert msg["depth"] == 5
+    assert msg["products"] == [
+        {"symbol": "A", "marketId": "MERV"},
+        {"symbol": "B", "marketId": "MERV"},
+    ]
+
+
+def test_subscribe_order_reports_all_accounts(capture_send: list[dict[str, Any]]) -> None:
+    _ws.ws_subscribe_order_reports()
+    assert capture_send == [{"type": "os"}]
+
+
+def test_subscribe_order_reports_single_account(capture_send: list[dict[str, Any]]) -> None:
+    _ws.ws_subscribe_order_reports(account="ACC1")
+    assert capture_send[0] == {"type": "os", "account": {"id": "ACC1"}}
+
+
+def test_subscribe_order_reports_multiple_accounts(
+    capture_send: list[dict[str, Any]],
+) -> None:
+    _ws.ws_subscribe_order_reports(accounts=["A", "B"], snapshot_only_active=True)
+    msg = capture_send[0]
+    assert msg["accounts"] == [{"id": "A"}, {"id": "B"}]
+    assert msg["snapshotOnlyActive"] is True
+
+
+def test_ws_new_order_minimal(capture_send: list[dict[str, Any]]) -> None:
+    _ws.ws_new_order("DLR/DIC23", "BUY", 1, "ACC1")
+    msg = capture_send[0]
+    assert msg["type"] == "no"
+    assert msg["product"] == {"marketId": "ROFX", "symbol": "DLR/DIC23"}
+    assert msg["quantity"] == 1
+    assert msg["side"] == "BUY"
+    assert msg["account"] == "ACC1"
+    assert msg["iceberg"] is False
+    assert "price" not in msg
+    assert "displayQuantity" not in msg
+
+
+def test_ws_new_order_full(capture_send: list[dict[str, Any]]) -> None:
+    _ws.ws_new_order(
+        "S",
+        "SELL",
+        10,
+        "A",
+        price=99.5,
+        iceberg=True,
+        display_quantity=2,
+        time_in_force="GTD",
+        expire_date="20260430",
+        ws_cl_ord_id="req-1",
+    )
+    msg = capture_send[0]
+    assert msg["price"] == 99.5
+    assert msg["iceberg"] is True
+    assert msg["displayQuantity"] == 2
+    assert msg["timeInForce"] == "GTD"
+    assert msg["expireDate"] == "20260430"
+    assert msg["wsClOrdId"] == "req-1"
+
+
+def test_ws_cancel_order(capture_send: list[dict[str, Any]]) -> None:
+    _ws.ws_cancel_order("cl-1", "PBCP")
+    assert capture_send == [{"type": "co", "clientId": "cl-1", "proprietary": "PBCP"}]

--- a/uv.lock
+++ b/uv.lock
@@ -69,12 +69,30 @@ wheels = [
 ]
 
 [[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
 name = "idna"
 version = "3.11"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/0703ccc57f3a7233505399edb88de3cbd678da106337b9fcde432b65ed60/idna-3.11.tar.gz", hash = "sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902", size = 194582, upload-time = "2025-10-12T14:55:20.501Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl", hash = "sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea", size = 71008, upload-time = "2025-10-12T14:55:18.883Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
 ]
 
 [[package]]
@@ -89,6 +107,7 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "pytest" },
     { name = "ruff" },
 ]
 
@@ -100,7 +119,53 @@ requires-dist = [
 ]
 
 [package.metadata.requires-dev]
-dev = [{ name = "ruff", specifier = ">=0.11.0" }]
+dev = [
+    { name = "pytest", specifier = ">=8.3.0" },
+    { name = "ruff", specifier = ">=0.11.0" },
+]
+
+[[package]]
+name = "packaging"
+version = "26.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/df/de/0d2b39fb4af88a0258f3bac87dfcbb48e73fbdea4a2ed0e2213f9a4c2f9a/packaging-26.1.tar.gz", hash = "sha256:f042152b681c4bfac5cae2742a55e103d27ab2ec0f3d88037136b6bfe7c9c5de", size = 215519, upload-time = "2026-04-14T21:12:49.362Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7a/c2/920ef838e2f0028c8262f16101ec09ebd5969864e5a64c4c05fad0617c56/packaging-26.1-py3-none-any.whl", hash = "sha256:5d9c0669c6285e491e0ced2eee587eaf67b670d94a19e94e3984a481aba6802f", size = 95831, upload-time = "2026-04-14T21:12:47.56Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.20.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.0.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
+]
 
 [[package]]
 name = "python-dotenv"


### PR DESCRIPTION
## Summary
- Agrega `pytest>=8.3.0` como dev dependency y configura `tool.pytest.ini_options` con `testpaths = ["tests"]`.
- Introduce 33 tests unitarios sobre `matriz_client.client`, `matriz_client.ws_client` y `matriz_client.exceptions`.
- Los tests mockean `requests.Session` y el `_send` del WebSocket, sin llamadas reales a la red.

Cierra BEC-6.

## Test plan
- [x] `uv run pytest` → 33 passed
- [x] `uv run ruff check .` → OK
- [x] `uv run ruff format --check .` → OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)