### PR TITLE
ci: add pytest job to CI workflow (BEC-7)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,3 +26,20 @@ jobs:
 
       - name: Format check with Ruff
         run: uv run ruff format --check .
+
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+
+      - name: Set up Python
+        run: uv python install
+
+      - name: Install dependencies
+        run: uv sync
+
+      - name: Run pytest
+        run: uv run pytest

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,9 +14,12 @@ uv sync
 
 # Run the example script
 uv run python main.py
+
+# Run the test suite
+uv run pytest
 ```
 
-There are no tests, linter, or formatter configured yet. Python 3.12+ is required (see `.python-version`).
+Python 3.12+ is required (see `.python-version`).
 
 ## Architecture
 
@@ -58,7 +61,7 @@ The full Primary API v1.21 specification is in `primary_api_llm.md` (LLM-optimiz
 - **Branch format**: `sebadlf-bec-{issue-number}-{short-description}` (copy from the Linear issue — it auto-generates this)
 - **PR body**: must include the Linear issue ID (e.g., `BEC-7`) — triggers auto-link in Linear
 - **Never commit directly to `main`** — protected branch, PR required
-- **CI must pass** before merge: Ruff lint + format check (`.github/workflows/ci.yml`)
+- **CI must pass** before merge: Ruff lint + format check, pytest (`.github/workflows/ci.yml`)
 
 ## Workflow
 


### PR DESCRIPTION
## Summary
- Agrega un job `test` en `.github/workflows/ci.yml` que corre `uv run pytest` en paralelo al job `lint` existente.
- Actualiza `CLAUDE.md` con el comando `uv run pytest` y menciona pytest como gate de CI.

Cierra BEC-7.

## Test plan
- [x] `uv run pytest` local → 33 passed
- [x] `uv run ruff check .` → OK
- [x] Ambos jobs (`lint` y `test`) deben pasar en el PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)