### PR TITLE
chore: add pyright type checker (BEC-10)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,3 +43,20 @@ jobs:
 
       - name: Run pytest
         run: uv run pytest
+
+  typecheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+
+      - name: Set up Python
+        run: uv python install
+
+      - name: Install dependencies
+        run: uv sync
+
+      - name: Type check with pyright
+        run: uv run pyright

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,6 +17,9 @@ uv run python main.py
 
 # Run the test suite
 uv run pytest
+
+# Run the type checker
+uv run pyright
 ```
 
 Python 3.12+ is required (see `.python-version`).
@@ -61,7 +64,7 @@ The full Primary API v1.21 specification is in `primary_api_llm.md` (LLM-optimiz
 - **Branch format**: `sebadlf-bec-{issue-number}-{short-description}` (copy from the Linear issue — it auto-generates this)
 - **PR body**: must include the Linear issue ID (e.g., `BEC-7`) — triggers auto-link in Linear
 - **Never commit directly to `main`** — protected branch, PR required
-- **CI must pass** before merge: Ruff lint + format check, pytest (`.github/workflows/ci.yml`)
+- **CI must pass** before merge: Ruff lint + format check, pytest, pyright (`.github/workflows/ci.yml`)
 
 ## Workflow
 

--- a/matriz_client/client.py
+++ b/matriz_client/client.py
@@ -20,7 +20,7 @@ _token: str | None = None
 _token_ts: float = 0.0
 _TOKEN_TTL = 23 * 60 * 60  # refresh 1 h before the 24 h expiry
 _session = _requests.Session()
-_session.timeout = 30.0
+_REQUEST_TIMEOUT = 30.0
 
 
 # ------------------------------------------------------------------
@@ -44,6 +44,7 @@ def login() -> str:
     resp = _session.post(
         f"{_base_url}/auth/getToken",
         headers={"X-Username": _user, "X-Password": _password},
+        timeout=_REQUEST_TIMEOUT,
     )
     resp.raise_for_status()
     token = resp.headers.get("X-Auth-Token")
@@ -69,11 +70,23 @@ def _request(
 ) -> dict[str, Any]:
     url = f"{_base_url}{path}"
     if auth_basic:
-        resp = _session.request(method, url, params=params, auth=HTTPBasicAuth(*auth_basic))
+        resp = _session.request(
+            method,
+            url,
+            params=params,
+            auth=HTTPBasicAuth(*auth_basic),
+            timeout=_REQUEST_TIMEOUT,
+        )
     else:
         _ensure_token()
         assert _token is not None
-        resp = _session.request(method, url, params=params, headers={"X-Auth-Token": _token})
+        resp = _session.request(
+            method,
+            url,
+            params=params,
+            headers={"X-Auth-Token": _token},
+            timeout=_REQUEST_TIMEOUT,
+        )
 
     resp.raise_for_status()
     data: dict[str, Any] = resp.json()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ dependencies = [
 
 [dependency-groups]
 dev = [
+    "pyright>=1.1.380",
     "pytest>=8.3.0",
     "ruff>=0.11.0",
 ]
@@ -19,6 +20,14 @@ dev = [
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 addopts = "-ra"
+
+[tool.pyright]
+include = ["matriz_client", "tests"]
+exclude = [".venv", "matriz-vault", "__pycache__", "utils"]
+pythonVersion = "3.12"
+typeCheckingMode = "standard"
+reportMissingImports = "error"
+reportMissingTypeStubs = "none"
 
 [tool.ruff]
 line-length = 100

--- a/uv.lock
+++ b/uv.lock
@@ -107,6 +107,7 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "pyright" },
     { name = "pytest" },
     { name = "ruff" },
 ]
@@ -120,8 +121,18 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "pyright", specifier = ">=1.1.380" },
     { name = "pytest", specifier = ">=8.3.0" },
     { name = "ruff", specifier = ">=0.11.0" },
+]
+
+[[package]]
+name = "nodeenv"
+version = "1.10.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/24/bf/d1bda4f6168e0b2e9e5958945e01910052158313224ada5ce1fb2e1113b8/nodeenv-1.10.0.tar.gz", hash = "sha256:996c191ad80897d076bdfba80a41994c2b47c68e224c542b48feba42ba00f8bb", size = 55611, upload-time = "2025-12-20T14:08:54.006Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/b2/d0896bdcdc8d28a7fc5717c305f1a861c26e18c05047949fb371034d98bd/nodeenv-1.10.0-py2.py3-none-any.whl", hash = "sha256:5bb13e3eed2923615535339b3c620e76779af4cb4c6a90deccc9e36b274d3827", size = 23438, upload-time = "2025-12-20T14:08:52.782Z" },
 ]
 
 [[package]]
@@ -149,6 +160,19 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pyright"
+version = "1.1.408"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nodeenv" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/74/b2/5db700e52554b8f025faa9c3c624c59f1f6c8841ba81ab97641b54322f16/pyright-1.1.408.tar.gz", hash = "sha256:f28f2321f96852fa50b5829ea492f6adb0e6954568d1caa3f3af3a5f555eb684", size = 4400578, upload-time = "2026-01-08T08:07:38.795Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/82/a2c93e32800940d9573fb28c346772a14778b84ba7524e691b324620ab89/pyright-1.1.408-py3-none-any.whl", hash = "sha256:090b32865f4fdb1e0e6cd82bf5618480d48eecd2eb2e70f960982a3d9a4c17c1", size = 6399144, upload-time = "2026-01-08T08:07:37.082Z" },
 ]
 
 [[package]]
@@ -214,6 +238,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/88/27/0195d15fe7a897cbcba0904792c4b7c9fdd958456c3a17d2ea6093716a9a/ruff-0.15.11-py3-none-win32.whl", hash = "sha256:476a2aa56b7da0b73a3ee80b6b2f0e19cce544245479adde7baa65466664d5f3", size = 10655535, upload-time = "2026-04-16T18:46:12.47Z" },
     { url = "https://files.pythonhosted.org/packages/3a/5e/c927b325bd4c1d3620211a4b96f47864633199feed60fa936025ab27e090/ruff-0.15.11-py3-none-win_amd64.whl", hash = "sha256:8b6756d88d7e234fb0c98c91511aae3cd519d5e3ed271cae31b20f39cb2a12a3", size = 11779692, upload-time = "2026-04-16T18:46:17.268Z" },
     { url = "https://files.pythonhosted.org/packages/63/b6/aeadee5443e49baa2facd51131159fd6301cc4ccfc1541e4df7b021c37dd/ruff-0.15.11-py3-none-win_arm64.whl", hash = "sha256:063fed18cc1bbe0ee7393957284a6fe8b588c6a406a285af3ee3f46da2391ee4", size = 11032614, upload-time = "2026-04-16T18:46:34.487Z" },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.15.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Agrega `pyright>=1.1.380` como dev dependency y lo configura en `[tool.pyright]` con modo `standard`, scope `matriz_client` + `tests` (excluye `utils/` que depende de `typing_extensions` no declarado — ver follow-up).
- Nuevo job `typecheck` en el workflow de CI.
- **Fix incidental**: `_session.timeout = 30.0` en `client.py` no tenía efecto (requests.Session no tiene atributo `timeout`). Ahora se pasa explícitamente como kwarg en cada `_session.request` / `_session.post` vía una constante `_REQUEST_TIMEOUT`.

Cierra BEC-10.

## Test plan
- [x] `uv run pyright` → 0 errors
- [x] `uv run pytest` → 33 passed
- [x] `uv run ruff check .` → OK
- [ ] CI `lint` + `test` + `typecheck` deben pasar

🤖 Generated with [Claude Code](https://claude.com/claude-code)