### PR TITLE
docs: expand docstrings across client modules (BEC-9)

### DIFF
--- a/matriz_client/__init__.py
+++ b/matriz_client/__init__.py
@@ -1,3 +1,17 @@
+"""Python client for the MATBA ROFEX Primary API v1.21.
+
+Re-exports the REST (:mod:`.client`) and WebSocket (:mod:`.ws_client`)
+surface as a flat namespace, so callers can simply do::
+
+    import matriz_client as primary
+
+    primary.login()
+    segments = primary.get_segments()
+    primary.ws_connect(on_message=my_handler)
+
+See the README and the in-module docstrings for usage details.
+"""
+
 from .client import (
     cancel_order,
     get_account_report,

--- a/matriz_client/client.py
+++ b/matriz_client/client.py
@@ -1,3 +1,23 @@
+"""REST client for the MATBA ROFEX Primary API v1.21.
+
+Thin wrapper over the HTTP endpoints of the Primary API. State is held at
+module level (token, session, credentials) and the token is refreshed
+automatically a little before the 24 h server-side expiry.
+
+Auth modes:
+- **Token** (default, most endpoints): obtained via ``POST /auth/getToken``
+  and sent as ``X-Auth-Token`` on every subsequent request.
+- **HTTP Basic** (Risk API only): uses ``PRIMARY_USER``/``PRIMARY_PASSWORD``
+  directly on each request.
+
+Environment variables (loaded from ``.env`` via ``python-dotenv``):
+- ``PRIMARY_USER`` — API username (required)
+- ``PRIMARY_PASSWORD`` — API password (required)
+- ``PRIMARY_BASE_URL`` — defaults to ``https://api.remarkets.primary.com.ar``
+
+See :mod:`matriz_client.ws_client` for the WebSocket streaming counterpart.
+"""
+
 from __future__ import annotations
 
 import os
@@ -29,6 +49,7 @@ _REQUEST_TIMEOUT = 30.0
 
 
 def _ensure_token() -> None:
+    """Log in if there is no cached token or it is older than ``_TOKEN_TTL``."""
     global _token, _token_ts
     if _token and (time.time() - _token_ts) < _TOKEN_TTL:
         return
@@ -36,7 +57,15 @@ def _ensure_token() -> None:
 
 
 def login() -> str:
-    """Authenticate and store the token. Returns the token string."""
+    """Authenticate against ``/auth/getToken`` and cache the resulting token.
+
+    Returns:
+        The newly issued token string, also stored in module state.
+
+    Raises:
+        AuthenticationError: If credentials are missing or the response has
+            no ``X-Auth-Token`` header.
+    """
     global _token, _token_ts
     if not _user or not _password:
         raise AuthenticationError("ERROR", "PRIMARY_USER and PRIMARY_PASSWORD must be set")
@@ -68,6 +97,15 @@ def _request(
     params: dict[str, Any] | None = None,
     auth_basic: tuple[str, str] | None = None,
 ) -> dict[str, Any]:
+    """Execute an HTTP request and decode the JSON payload.
+
+    When ``auth_basic`` is provided, HTTP Basic Auth is used and the token
+    flow is skipped (Risk API). Otherwise, the token is ensured/refreshed
+    and sent via ``X-Auth-Token``.
+
+    Raises:
+        PrimaryAPIError: If the decoded payload has ``status == "ERROR"``.
+    """
     url = f"{_base_url}{path}"
     if auth_basic:
         resp = _session.request(
@@ -100,11 +138,13 @@ def _request(
 
 
 def _get(path: str, **params: Any) -> dict[str, Any]:
+    """GET ``path`` with ``params`` after dropping keys whose value is ``None``."""
     clean = {k: v for k, v in params.items() if v is not None}
     return _request("GET", path, params=clean)
 
 
 def _risk_auth() -> tuple[str, str]:
+    """Return the (user, password) tuple used for Risk API HTTP Basic Auth."""
     return (_user, _password)
 
 
@@ -114,7 +154,7 @@ def _risk_auth() -> tuple[str, str]:
 
 
 def get_segments() -> list[dict[str, str]]:
-    """Return all available market segments."""
+    """Return all available market segments (``DDF``, ``DDA``, ``DUAL``, ``MERV``)."""
     return _get("/rest/segment/all")["segments"]
 
 
@@ -124,27 +164,37 @@ def get_segments() -> list[dict[str, str]]:
 
 
 def get_all_instruments() -> list[dict[str, Any]]:
-    """Return all instruments (basic info)."""
+    """Return all tradable instruments with basic info (symbol + marketId)."""
     return _get("/rest/instruments/all")["instruments"]
 
 
 def get_instruments_details() -> list[dict[str, Any]]:
-    """Return all instruments with full detail."""
+    """Return all instruments with full detail (tick size, contract size, etc.)."""
     return _get("/rest/instruments/details")["instruments"]
 
 
 def get_instrument_detail(symbol: str, market_id: str = "ROFX") -> dict[str, Any]:
-    """Return detail for a single instrument."""
+    """Return the full detail record for a single instrument.
+
+    Args:
+        symbol: Instrument symbol (e.g. ``"DLR/DIC23"``).
+        market_id: Market identifier; defaults to ``"ROFX"``.
+    """
     return _get("/rest/instruments/detail", symbol=symbol, marketId=market_id)["instrument"]
 
 
 def get_instruments_by_cfi(cfi_code: str) -> list[dict[str, Any]]:
-    """Return instruments filtered by CFI code."""
+    """Return instruments filtered by ISO 10962 CFI code (e.g. ``"FXXXSX"``)."""
     return _get("/rest/instruments/byCFICode", CFICode=cfi_code)["instruments"]
 
 
 def get_instruments_by_segment(segment_id: str, market_id: str = "ROFX") -> list[dict[str, Any]]:
-    """Return instruments in a given segment."""
+    """Return instruments belonging to the given market segment.
+
+    Args:
+        segment_id: One of ``"DDF"``, ``"DDA"``, ``"DUAL"``, ``"MERV"``.
+        market_id: Market identifier; defaults to ``"ROFX"``.
+    """
     return _get("/rest/instruments/bySegment", MarketSegmentID=segment_id, MarketID=market_id)[
         "instruments"
     ]
@@ -170,7 +220,30 @@ def new_order(
     display_qty: int | None = None,
     expire_date: str | None = None,
 ) -> dict[str, Any]:
-    """Submit a new order. Returns {"clientId": ..., "proprietary": ...}."""
+    """Submit a new single order.
+
+    Note: The Primary API accepts order submission over HTTP **GET**; this
+    is a quirk of the upstream API, not a bug in this client.
+
+    Args:
+        symbol: Instrument symbol (e.g. ``"DLR/DIC23"``).
+        side: ``"BUY"`` or ``"SELL"``.
+        qty: Order quantity.
+        account: Account ID to submit the order on behalf of.
+        price: Limit price; required for ``order_type="LIMIT"``.
+        order_type: ``"LIMIT"`` or ``"MARKET"``; defaults to ``"LIMIT"``.
+        time_in_force: ``"DAY"``, ``"IOC"``, ``"FOK"`` or ``"GTD"``.
+        market_id: Market identifier; defaults to ``"ROFX"``.
+        cancel_previous: If ``True``, cancel previous active orders for the
+            same instrument/account before placing this one.
+        iceberg: Whether the order is iceberg (requires ``display_qty``).
+        display_qty: Visible quantity for iceberg orders.
+        expire_date: Expiry date for ``GTD`` orders (``"YYYYMMDD"``).
+
+    Returns:
+        Mapping with ``{"clientId": ..., "proprietary": ...}`` — together
+        they identify the request in every subsequent call.
+    """
     params: dict[str, Any] = {
         "marketId": market_id,
         "symbol": symbol,
@@ -193,7 +266,11 @@ def new_order(
 
 
 def replace_order(cl_ord_id: str, proprietary: str, qty: int, price: float) -> dict[str, Any]:
-    """Replace (modify) an existing order by clOrdId."""
+    """Modify an existing order, identified by ``(clOrdId, proprietary)``.
+
+    Replacing an order atomically cancels the original and creates a new
+    one with the same ``clOrdId`` but a new ``orderId`` at the exchange.
+    """
     return _get(
         "/rest/order/replaceById",
         clOrdId=cl_ord_id,
@@ -204,37 +281,37 @@ def replace_order(cl_ord_id: str, proprietary: str, qty: int, price: float) -> d
 
 
 def cancel_order(cl_ord_id: str, proprietary: str) -> dict[str, Any]:
-    """Cancel an order by clOrdId."""
+    """Cancel the order identified by ``(clOrdId, proprietary)``."""
     return _get("/rest/order/cancelById", clOrdId=cl_ord_id, proprietary=proprietary)
 
 
 def get_order_status(cl_ord_id: str, proprietary: str) -> dict[str, Any]:
-    """Get the latest status of a request by clOrdId."""
+    """Return the latest status record for the request ``(clOrdId, proprietary)``."""
     return _get("/rest/order/id", clOrdId=cl_ord_id, proprietary=proprietary)["order"]
 
 
 def get_order_history(cl_ord_id: str, proprietary: str) -> dict[str, Any]:
-    """Get all status transitions for a request by clOrdId."""
+    """Return the full list of status transitions for ``(clOrdId, proprietary)``."""
     return _get("/rest/order/allById", clOrdId=cl_ord_id, proprietary=proprietary)
 
 
 def get_active_orders(account_id: str) -> dict[str, Any]:
-    """Get all active orders for an account."""
+    """Return all orders currently active (``NEW`` or ``PARTIALLY_FILLED``) for an account."""
     return _get("/rest/order/actives", accountId=account_id)
 
 
 def get_filled_orders(account_id: str) -> dict[str, Any]:
-    """Get all filled orders for an account."""
+    """Return all fully filled orders for an account."""
     return _get("/rest/order/filleds", accountId=account_id)
 
 
 def get_all_orders(account_id: str) -> dict[str, Any]:
-    """Get latest status of all requests for an account."""
+    """Return the latest status record of every request sent by an account."""
     return _get("/rest/order/all", accountId=account_id)
 
 
 def get_order_by_exec_id(exec_id: str) -> dict[str, Any]:
-    """Get an order by its execution ID."""
+    """Return the order matching the given execution ID (``execId``)."""
     return _get("/rest/order/byExecId", execId=exec_id)
 
 
@@ -250,7 +327,16 @@ def get_market_data(
     market_id: str = "ROFX",
     depth: int | None = None,
 ) -> dict[str, Any]:
-    """Get real-time market data for an instrument."""
+    """Return real-time market data for an instrument.
+
+    Args:
+        symbol: Instrument symbol (e.g. ``"DLR/DIC23"``).
+        entries: Comma-separated list of entry codes:
+            ``BI`` (bid), ``OF`` (offer), ``LA`` (last), ``OP`` (open),
+            ``CL`` (close), ``SE`` (settlement), ``OI`` (open interest).
+        market_id: Market identifier; defaults to ``"ROFX"``.
+        depth: Book depth (1-5); ``None`` uses the server default.
+    """
     return _get(
         "/rest/marketdata/get",
         marketId=market_id,
@@ -269,7 +355,11 @@ def get_trades(
     market_id: str = "ROFX",
     environment: str | None = None,
 ) -> list[dict[str, Any]]:
-    """Get historical trades for an instrument."""
+    """Return historical trades for an instrument.
+
+    Use ``date`` for a single day, or the ``date_from``/``date_to`` pair
+    for a range. Dates must be in ``"YYYY-MM-DD"`` format.
+    """
     return _get(
         "/rest/data/getTrades",
         marketId=market_id,
@@ -287,7 +377,7 @@ def get_trades(
 
 
 def get_positions(account_name: str) -> dict[str, Any]:
-    """Get positions for an account (Risk API)."""
+    """Return aggregated positions for an account (Risk API, HTTP Basic Auth)."""
     return _request(
         "GET",
         f"/rest/risk/position/getPositions/{account_name}",
@@ -296,10 +386,10 @@ def get_positions(account_name: str) -> dict[str, Any]:
 
 
 def get_detailed_positions(account_name: str) -> dict[str, Any]:
-    """Get detailed positions for an account (Risk API)."""
+    """Return trade-level detailed positions for an account (Risk API)."""
     return _request("GET", f"/rest/risk/detailedPosition/{account_name}", auth_basic=_risk_auth())
 
 
 def get_account_report(account_name: str) -> dict[str, Any]:
-    """Get account report (Risk API)."""
+    """Return the full account report (cash, margins, P&L) for an account (Risk API)."""
     return _request("GET", f"/rest/risk/accountReport/{account_name}", auth_basic=_risk_auth())

--- a/matriz_client/exceptions.py
+++ b/matriz_client/exceptions.py
@@ -1,5 +1,20 @@
+"""Exception hierarchy for Primary API errors."""
+
+from __future__ import annotations
+
+
 class PrimaryAPIError(Exception):
-    """Error returned by the Primary API."""
+    """Error returned by the Primary API.
+
+    Raised when a response comes back with ``status == "ERROR"``. The
+    original ``description``/``message`` fields from the API payload are
+    preserved as attributes for programmatic inspection.
+
+    Attributes:
+        status: Always ``"ERROR"`` for failed responses.
+        description: Human-readable description from the API, if present.
+        api_message: Lower-level message string from the API, if present.
+    """
 
     def __init__(self, status: str, description: str | None = None, message: str | None = None):
         self.status = status
@@ -10,4 +25,4 @@ class PrimaryAPIError(Exception):
 
 
 class AuthenticationError(PrimaryAPIError):
-    """Failed to authenticate against the Primary API."""
+    """Raised when authentication fails or no token is returned by the API."""

--- a/matriz_client/ws_client.py
+++ b/matriz_client/ws_client.py
@@ -1,3 +1,17 @@
+"""WebSocket streaming client for the MATBA ROFEX Primary API.
+
+Provides real-time market data and execution-report subscriptions, plus
+order entry/cancel over the same connection. The WebSocket URL is derived
+from the REST base URL by swapping the scheme (``https`` → ``wss``), and
+the connection authenticates with the cached REST token, so
+:func:`matriz_client.client.login` must have succeeded before
+:func:`ws_connect`.
+
+The connection runs its event loop in a background daemon thread. All
+inbound frames are dispatched to the user-provided callbacks registered
+at :func:`ws_connect` time.
+"""
+
 from __future__ import annotations
 
 import json


### PR DESCRIPTION
## Summary
- Docstrings a nivel módulo en `matriz_client/__init__.py`, `client.py`, `ws_client.py` y `exceptions.py` con overview de auth, env vars y uso típico.
- Docstrings extendidas (Args / Returns / Raises) en las funciones públicas de `client.py`; se mantiene el estilo corto donde el nombre ya es auto-descriptivo.
- Notas explícitas sobre peculiaridades de la API upstream: `new_order` se envía por HTTP GET, la Risk API usa HTTP Basic Auth.

Cierra BEC-9.

## Test plan
- [x] `uv run pytest` → 33 passed
- [x] `uv run pyright` → 0 errors
- [x] `uv run ruff check .` / `ruff format --check .` → OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)