### PR TITLE
feat: expose market-data entry catalogue + WS level (BEC-8)

### DIFF
--- a/matriz_client/__init__.py
+++ b/matriz_client/__init__.py
@@ -37,6 +37,8 @@ from .client import (
 )
 from .exceptions import AuthenticationError, PrimaryAPIError
 from .ws_client import (
+    DEFAULT_MARKET_DATA_ENTRIES,
+    MARKET_DATA_ENTRIES,
     ws_cancel_order,
     ws_connect,
     ws_disconnect,
@@ -47,6 +49,8 @@ from .ws_client import (
 )
 
 __all__ = [
+    "DEFAULT_MARKET_DATA_ENTRIES",
+    "MARKET_DATA_ENTRIES",
     "AuthenticationError",
     "PrimaryAPIError",
     # REST

--- a/matriz_client/ws_client.py
+++ b/matriz_client/ws_client.py
@@ -28,6 +28,36 @@ MessageCallback = Callable[[dict[str, Any]], None]
 ErrorCallback = Callable[[Exception], None]
 CloseCallback = Callable[[], None]
 
+# Full catalogue of market-data entry codes recognized by the Primary API.
+# See §8.3 of the Primary API spec (``primary_api_llm.md``).
+MARKET_DATA_ENTRIES: tuple[str, ...] = (
+    "BI",  # best bid
+    "OF",  # best offer
+    "LA",  # last traded price
+    "OP",  # open price
+    "CL",  # previous close
+    "SE",  # settlement
+    "HI",  # session high
+    "LO",  # session low
+    "TV",  # traded volume
+    "OI",  # open interest
+    "IV",  # index value
+    "EV",  # effective volume (ByMA)
+    "NV",  # nominal volume (ByMA)
+    "ACP",  # today's close
+)
+
+# Default subset used when the caller does not specify ``entries``.
+DEFAULT_MARKET_DATA_ENTRIES: tuple[str, ...] = (
+    "BI",
+    "OF",
+    "LA",
+    "OP",
+    "CL",
+    "SE",
+    "OI",
+)
+
 # -- Module-level state --
 _ws: websocket.WebSocketApp | None = None
 _ws_thread: threading.Thread | None = None
@@ -155,22 +185,35 @@ def ws_subscribe_market_data(
     *,
     market_id: str = "ROFX",
     depth: int = 1,
+    level: int = 1,
 ) -> None:
     """Subscribe to real-time market data for one or more instruments.
 
+    Incoming messages arrive via the ``on_message`` callback registered with
+    :func:`ws_connect` and have ``type == "Md"`` (see §8.2 of the spec).
+
     Args:
-        symbols: List of instrument symbols (e.g. ["DLR/DIC23", "SOJ.ROS/MAY23"]).
-        entries: Market data entries to receive (e.g. ["BI", "OF", "LA"]).
-                 Defaults to ["BI", "OF", "LA", "OP", "CL", "SE", "OI"].
-        market_id: Market identifier, defaults to "ROFX".
+        symbols: List of instrument symbols (e.g. ``["DLR/DIC23", "SOJ.ROS/MAY23"]``).
+        entries: Entry codes to receive (see :data:`MARKET_DATA_ENTRIES`).
+            Defaults to :data:`DEFAULT_MARKET_DATA_ENTRIES`.
+        market_id: Market identifier, defaults to ``"ROFX"``.
         depth: Book depth (1-5), defaults to 1.
+        level: Market-data level as defined by the Primary API, defaults to 1.
+
+    Raises:
+        ValueError: If ``entries`` contains codes that are not recognized.
+        RuntimeError: If the WebSocket is not connected.
     """
     if entries is None:
-        entries = ["BI", "OF", "LA", "OP", "CL", "SE", "OI"]
+        entries = list(DEFAULT_MARKET_DATA_ENTRIES)
+    else:
+        unknown = set(entries) - set(MARKET_DATA_ENTRIES)
+        if unknown:
+            raise ValueError(f"Unknown market data entries: {sorted(unknown)}")
 
     msg: dict[str, Any] = {
         "type": "smd",
-        "level": 1,
+        "level": level,
         "entries": entries,
         "products": [{"symbol": s, "marketId": market_id} for s in symbols],
         "depth": depth,

--- a/tests/test_ws_client.py
+++ b/tests/test_ws_client.py
@@ -144,3 +144,77 @@ def test_ws_new_order_full(capture_send: list[dict[str, Any]]) -> None:
 def test_ws_cancel_order(capture_send: list[dict[str, Any]]) -> None:
     _ws.ws_cancel_order("cl-1", "PBCP")
     assert capture_send == [{"type": "co", "clientId": "cl-1", "proprietary": "PBCP"}]
+
+
+# ------------------------------------------------------------------
+# Entry validation and level
+# ------------------------------------------------------------------
+
+
+def test_subscribe_market_data_rejects_unknown_entries(
+    capture_send: list[dict[str, Any]],
+) -> None:
+    with pytest.raises(ValueError, match="Unknown market data entries"):
+        _ws.ws_subscribe_market_data(["A"], entries=["BI", "BOGUS"])
+    assert capture_send == []
+
+
+def test_subscribe_market_data_accepts_full_entry_catalogue(
+    capture_send: list[dict[str, Any]],
+) -> None:
+    _ws.ws_subscribe_market_data(["A"], entries=list(_ws.MARKET_DATA_ENTRIES))
+    assert capture_send[0]["entries"] == list(_ws.MARKET_DATA_ENTRIES)
+
+
+def test_subscribe_market_data_custom_level(capture_send: list[dict[str, Any]]) -> None:
+    _ws.ws_subscribe_market_data(["A"], level=2)
+    assert capture_send[0]["level"] == 2
+
+
+# ------------------------------------------------------------------
+# Inbound handlers
+# ------------------------------------------------------------------
+
+
+def test_handle_message_invokes_callback(monkeypatch: pytest.MonkeyPatch) -> None:
+    received: list[dict[str, Any]] = []
+    monkeypatch.setattr(_ws, "_on_message", received.append)
+    _ws._handle_message(MagicMock(), '{"type": "Md", "marketData": {}}')
+    assert received == [{"type": "Md", "marketData": {}}]
+
+
+def test_handle_message_noop_without_callback(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(_ws, "_on_message", None)
+    _ws._handle_message(MagicMock(), '{"type": "Md"}')
+
+
+def test_handle_error_invokes_callback(monkeypatch: pytest.MonkeyPatch) -> None:
+    received: list[Exception] = []
+    monkeypatch.setattr(_ws, "_on_error", received.append)
+    err = RuntimeError("boom")
+    _ws._handle_error(MagicMock(), err)
+    assert received == [err]
+
+
+def test_handle_open_sets_event(monkeypatch: pytest.MonkeyPatch) -> None:
+    _ws._connected.clear()
+    _ws._handle_open(MagicMock())
+    try:
+        assert _ws._connected.is_set()
+    finally:
+        _ws._connected.clear()
+
+
+def test_handle_close_clears_event_and_invokes_callback(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    called = {"n": 0}
+
+    def cb() -> None:
+        called["n"] += 1
+
+    _ws._connected.set()
+    monkeypatch.setattr(_ws, "_on_close", cb)
+    _ws._handle_close(MagicMock(), 1000, "normal")
+    assert called["n"] == 1
+    assert not _ws._connected.is_set()


### PR DESCRIPTION
## Summary
- Constantes públicas `MARKET_DATA_ENTRIES` (catálogo completo: `BI`, `OF`, `LA`, `OP`, `CL`, `SE`, `HI`, `LO`, `TV`, `OI`, `IV`, `EV`, `NV`, `ACP`) y `DEFAULT_MARKET_DATA_ENTRIES` (subset por defecto), re-exportadas desde `matriz_client`.
- `ws_subscribe_market_data` valida los `entries` contra el catálogo y lanza `ValueError` si alguno no está reconocido.
- Nuevo parámetro `level` en `ws_subscribe_market_data` (default `1`, antes estaba hardcoded).
- Cobertura de pytest para handlers entrantes (`_handle_message`, `_handle_open`, `_handle_close`, `_handle_error`), validación de entries y el `level`.

Cierra BEC-8.

## Test plan
- [x] `uv run pytest` → 41 passed (8 nuevos)
- [x] `uv run pyright` → 0 errors
- [x] `uv run ruff check .` / `ruff format --check .` → OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)