### PR TITLE
ci: add auto-merge workflow for pull requests

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,0 +1,19 @@
+name: Enable auto-merge
+
+on:
+  pull_request:
+    types: [opened, reopened, ready_for_review]
+
+jobs:
+  enable-auto-merge:
+    if: github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      contents: write
+    steps:
+      - name: Enable auto-merge (squash)
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_URL: ${{ github.event.pull_request.html_url }}


### PR DESCRIPTION
## Summary
- Agrega `.github/workflows/auto-merge.yml` que habilita auto-merge (squash) en PRs `opened`/`reopened`/`ready_for_review`
- Evita correr `gh pr merge --auto` manualmente en cada PR
- El merge real sigue esperando a que pasen los required status checks definidos en branch protection

Closes BEC-20

## Test plan
- [ ] Al mergear, verificar que este mismo PR no dispara loops raros (el workflow corre sobre PRs nuevos, no sobre pushes a `main`)
- [ ] Abrir un PR posterior y confirmar que aparece marcado como "auto-merge enabled" automáticamente