### PR TITLE
types: tighten signatures of market data endpoints

### DIFF
--- a/matriz_client/client.py
+++ b/matriz_client/client.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 
 import os
 import time
+from collections.abc import Sequence
 from typing import Any
 
 import requests as _requests
@@ -30,9 +31,12 @@ from requests.auth import HTTPBasicAuth
 
 from .exceptions import AuthenticationError, PrimaryAPIError
 from .types import (
+    DEFAULT_MARKET_DATA_ENTRIES,
     CFICode,
     Instrument,
     InstrumentDetail,
+    MarketDataEntry,
+    MarketDataSnapshot,
     MarketId,
     NewOrderResponse,
     Order,
@@ -41,6 +45,7 @@ from .types import (
     SegmentId,
     Side,
     TimeInForce,
+    Trade,
 )
 
 load_dotenv()
@@ -364,18 +369,19 @@ def get_order_by_exec_id(exec_id: str) -> Order:
 
 def get_market_data(
     symbol: str,
-    entries: str = "BI,OF,LA,OP,CL,SE,OI",
+    entries: Sequence[MarketDataEntry] = DEFAULT_MARKET_DATA_ENTRIES,
     *,
-    market_id: str = "ROFX",
+    market_id: MarketId = "ROFX",
     depth: int | None = None,
-) -> dict[str, Any]:
-    """Return real-time market data for an instrument.
+) -> MarketDataSnapshot:
+    """Return real-time market data for an instrument (§8.1).
 
     Args:
         symbol: Instrument symbol (e.g. ``"DLR/DIC23"``).
-        entries: Comma-separated list of entry codes:
-            ``BI`` (bid), ``OF`` (offer), ``LA`` (last), ``OP`` (open),
-            ``CL`` (close), ``SE`` (settlement), ``OI`` (open interest).
+        entries: Sequence of entry codes — see
+            :data:`~matriz_client.types.MARKET_DATA_ENTRIES` for the full
+            catalogue. Defaults to
+            :data:`~matriz_client.types.DEFAULT_MARKET_DATA_ENTRIES`.
         market_id: Market identifier; defaults to ``"ROFX"``.
         depth: Book depth (1-5); ``None`` uses the server default.
     """
@@ -383,7 +389,7 @@ def get_market_data(
         "/rest/marketdata/get",
         marketId=market_id,
         symbol=symbol,
-        entries=entries,
+        entries=",".join(entries),
         depth=depth,
     )["marketData"]
 
@@ -394,10 +400,10 @@ def get_trades(
     date: str | None = None,
     date_from: str | None = None,
     date_to: str | None = None,
-    market_id: str = "ROFX",
+    market_id: MarketId = "ROFX",
     environment: str | None = None,
-) -> list[dict[str, Any]]:
-    """Return historical trades for an instrument.
+) -> list[Trade]:
+    """Return historical trades for an instrument (§8.4).
 
     Use ``date`` for a single day, or the ``date_from``/``date_to`` pair
     for a range. Dates must be in ``"YYYY-MM-DD"`` format.

--- a/matriz_client/types.py
+++ b/matriz_client/types.py
@@ -51,6 +51,9 @@ __all__ = [
     "Position",
     "Segment",
     "Trade",
+    # Constants
+    "DEFAULT_MARKET_DATA_ENTRIES",
+    "MARKET_DATA_ENTRIES",
 ]
 
 
@@ -120,6 +123,40 @@ OrderStatus = Literal[
 
 Currency = Literal["ARS", "USD"]
 """Currency observed in instrument detail responses."""
+
+
+# ----------------------------------------------------------------------
+# Market-data entry catalogues (§8.3)
+# ----------------------------------------------------------------------
+
+MARKET_DATA_ENTRIES: tuple[MarketDataEntry, ...] = (
+    "BI",  # best bid
+    "OF",  # best offer
+    "LA",  # last traded price
+    "OP",  # open price
+    "CL",  # previous close
+    "SE",  # settlement
+    "HI",  # session high
+    "LO",  # session low
+    "TV",  # traded volume
+    "OI",  # open interest
+    "IV",  # index value
+    "EV",  # effective volume (ByMA)
+    "NV",  # nominal volume (ByMA)
+    "ACP",  # today's close
+)
+"""Full catalogue of market-data entry codes recognised by the Primary API."""
+
+DEFAULT_MARKET_DATA_ENTRIES: tuple[MarketDataEntry, ...] = (
+    "BI",
+    "OF",
+    "LA",
+    "OP",
+    "CL",
+    "SE",
+    "OI",
+)
+"""Default subset used when the caller does not specify ``entries``."""
 
 
 # ----------------------------------------------------------------------

--- a/matriz_client/ws_client.py
+++ b/matriz_client/ws_client.py
@@ -22,41 +22,24 @@ from typing import Any
 import websocket
 
 from . import client as _rest
+from .types import DEFAULT_MARKET_DATA_ENTRIES, MARKET_DATA_ENTRIES
 
 # -- Types --
 MessageCallback = Callable[[dict[str, Any]], None]
 ErrorCallback = Callable[[Exception], None]
 CloseCallback = Callable[[], None]
 
-# Full catalogue of market-data entry codes recognized by the Primary API.
-# See §8.3 of the Primary API spec (``primary_api_llm.md``).
-MARKET_DATA_ENTRIES: tuple[str, ...] = (
-    "BI",  # best bid
-    "OF",  # best offer
-    "LA",  # last traded price
-    "OP",  # open price
-    "CL",  # previous close
-    "SE",  # settlement
-    "HI",  # session high
-    "LO",  # session low
-    "TV",  # traded volume
-    "OI",  # open interest
-    "IV",  # index value
-    "EV",  # effective volume (ByMA)
-    "NV",  # nominal volume (ByMA)
-    "ACP",  # today's close
-)
-
-# Default subset used when the caller does not specify ``entries``.
-DEFAULT_MARKET_DATA_ENTRIES: tuple[str, ...] = (
-    "BI",
-    "OF",
-    "LA",
-    "OP",
-    "CL",
-    "SE",
-    "OI",
-)
+__all__ = [
+    "DEFAULT_MARKET_DATA_ENTRIES",
+    "MARKET_DATA_ENTRIES",
+    "ws_cancel_order",
+    "ws_connect",
+    "ws_disconnect",
+    "ws_is_connected",
+    "ws_new_order",
+    "ws_subscribe_market_data",
+    "ws_subscribe_order_reports",
+]
 
 # -- Module-level state --
 _ws: websocket.WebSocketApp | None = None


### PR DESCRIPTION
## Summary
- Move `MARKET_DATA_ENTRIES` / `DEFAULT_MARKET_DATA_ENTRIES` to `types.py` so the catalogue has a single source of truth; `ws_client` now re-exports them.
- `get_market_data()` takes `Sequence[MarketDataEntry]` (default `DEFAULT_MARKET_DATA_ENTRIES`) and returns `MarketDataSnapshot`.
- `get_trades()` returns `list[Trade]` and uses `MarketId` for `market_id`.

**Breaking change**: `get_market_data(entries=...)` is no longer a CSV string — pass a sequence of `MarketDataEntry` literals instead.

Closes BEC-18

## Test plan
- [x] `uv run ruff check .` — clean
- [x] `uv run ruff format --check .` — clean
- [x] `uv run pytest` — 43 passed
- [x] `uv run pyright` — 0 errors