### PR TITLE
build: make matriz_client pip-installable (BEC-11)

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Sebastián de la Fuente
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,86 @@
+# matriz-client
+
+Python client for the [MATBA ROFEX Primary API v1.21](./primary_api_llm.md) — a REST + WebSocket API for electronic trading on Argentina's derivatives and securities exchange. The library wraps every public endpoint (segments, instruments, orders, market data, risk) into typed Python functions with automatic token management.
+
+Requires Python 3.12+.
+
+## Installation
+
+Install from a built wheel (GitHub Releases):
+
+```bash
+pip install https://github.com/sebadlf/matriz-client/releases/download/<VERSION>/matriz_client-<VERSION>-py3-none-any.whl
+```
+
+Or clone and install from source:
+
+```bash
+git clone https://github.com/sebadlf/matriz-client.git
+cd matriz-client
+uv sync
+```
+
+## Configuration
+
+The client loads credentials from environment variables (or a `.env` file via `python-dotenv`):
+
+| Variable | Description |
+|---|---|
+| `PRIMARY_USER` | API username (required) |
+| `PRIMARY_PASSWORD` | API password (required) |
+| `PRIMARY_BASE_URL` | REST base URL. Defaults to `https://api.remarkets.primary.com.ar` (reMarkets sandbox). |
+
+## Quickstart — REST
+
+```python
+import matriz_client as primary
+
+primary.login()
+
+segments = primary.get_segments()
+instruments = primary.get_instruments_by_segment("DDF")
+
+snapshot = primary.get_market_data("DLR/DIC23", depth=5)
+print(snapshot["BI"], snapshot["OF"])
+
+resp = primary.new_order(
+    symbol="DLR/DIC23",
+    side="BUY",
+    qty=10,
+    account="REM6771",
+    price=210.5,
+)
+print(resp["clientId"], resp["proprietary"])
+```
+
+## Quickstart — WebSocket
+
+```python
+import matriz_client as primary
+
+
+def on_md(msg: dict) -> None:
+    print("MD event:", msg)
+
+
+primary.login()
+primary.ws_connect(on_message=on_md)
+primary.ws_subscribe_market_data(["DLR/DIC23"], depth=5)
+```
+
+## Typed API
+
+`matriz_client` ships a `py.typed` marker (PEP 561) and exports `Literal` / `TypedDict` definitions for every enum-like parameter and JSON response. Import them from the flat namespace:
+
+```python
+from matriz_client import Side, OrderType, TimeInForce, Order, MarketDataSnapshot
+```
+
+## Reference
+
+- Full Primary API v1.21 spec: [`primary_api_llm.md`](./primary_api_llm.md)
+- Public surface: `matriz_client.__all__`
+
+## License
+
+MIT © Sebastián de la Fuente

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,20 +1,76 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
 [project]
 name = "matriz-client"
 version = "0.1.0"
-description = "Add your description here"
+description = "Python client for the MATBA ROFEX Primary API v1.21 (REST + WebSocket)."
 readme = "README.md"
 requires-python = ">=3.12"
+license = "MIT"
+authors = [
+    { name = "Sebastián de la Fuente", email = "sebadlf@gmail.com" },
+]
+keywords = [
+    "matba-rofex",
+    "primary-api",
+    "trading",
+    "argentina",
+    "derivatives",
+    "websocket",
+]
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "Intended Audience :: Financial and Insurance Industry",
+    "Operating System :: OS Independent",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.12",
+    "Topic :: Office/Business :: Financial :: Investment",
+    "Typing :: Typed",
+]
 dependencies = [
     "python-dotenv>=1.2.2",
     "requests>=2.32.5",
     "websocket-client>=1.8.0",
 ]
 
+[project.urls]
+Homepage = "https://github.com/sebadlf/matriz-client"
+Repository = "https://github.com/sebadlf/matriz-client"
+Issues = "https://github.com/sebadlf/matriz-client/issues"
+
 [dependency-groups]
 dev = [
     "pyright>=1.1.380",
     "pytest>=8.3.0",
     "ruff>=0.11.0",
+]
+
+[tool.hatch.build.targets.wheel]
+packages = ["matriz_client"]
+
+[tool.hatch.build.targets.sdist]
+include = [
+    "matriz_client",
+    "README.md",
+    "LICENSE",
+    "primary_api_llm.md",
+    "pyproject.toml",
+]
+exclude = [
+    "matriz-vault",
+    "tests",
+    "utils",
+    ".github",
+    ".claude",
+    "main*.py",
+    "keys.py",
+    "Primary-API.*",
+    "*.ipynb",
+    ".env*",
+    "dist",
 ]
 
 [tool.pytest.ini_options]

--- a/uv.lock
+++ b/uv.lock
@@ -98,7 +98,7 @@ wheels = [
 [[package]]
 name = "matriz-client"
 version = "0.1.0"
-source = { virtual = "." }
+source = { editable = "." }
 dependencies = [
     { name = "python-dotenv" },
     { name = "requests" },


### PR DESCRIPTION
## Summary
- Configure hatchling build backend and full PEP 621 metadata in `pyproject.toml`
- Add MIT `LICENSE` and a proper `README.md` with install/config/usage
- Whitelist sdist content (exclude `matriz-vault/`, `tests/`, `utils/`, etc.); wheel already ships only the package
- `py.typed` marker + `Typing :: Typed` classifier for PEP 561 consumers

Closes BEC-11

## Test plan
- [x] `uv build` produces clean wheel (package-only) and sdist
- [x] `pip install` of the wheel in a clean venv works; `import matriz_client` succeeds
- [x] `uv run ruff check` / `ruff format --check` / `pytest` / `pyright` all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)