### PR TITLE
ci: add tag-triggered GitHub Release workflow (BEC-12)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,44 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+
+      - name: Set up Python
+        run: uv python install
+
+      - name: Verify tag matches pyproject.toml version
+        run: |
+          tag="${GITHUB_REF_NAME#v}"
+          project_version=$(uv run python -c "import tomllib,pathlib; print(tomllib.loads(pathlib.Path('pyproject.toml').read_text())['project']['version'])")
+          echo "tag=$tag project=$project_version"
+          if [ "$tag" != "$project_version" ]; then
+            echo "::error::Tag $GITHUB_REF_NAME does not match pyproject.toml version $project_version"
+            exit 1
+          fi
+
+      - name: Build distributions
+        run: uv build
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          name: ${{ github.ref_name }}
+          files: |
+            dist/*.whl
+            dist/*.tar.gz
+          fail_on_unmatched_files: true
+          generate_release_notes: true

--- a/README.md
+++ b/README.md
@@ -81,6 +81,17 @@ from matriz_client import Side, OrderType, TimeInForce, Order, MarketDataSnapsho
 - Full Primary API v1.21 spec: [`primary_api_llm.md`](./primary_api_llm.md)
 - Public surface: `matriz_client.__all__`
 
+## Releases
+
+Distribution happens via GitHub Releases (no PyPI). The [`release.yml`](.github/workflows/release.yml) workflow builds and publishes a wheel + sdist on every `v*` tag push.
+
+Cutting a new release:
+
+1. Bump `project.version` in `pyproject.toml`.
+2. Commit and merge the bump to `main`.
+3. Tag the commit: `git tag v0.1.0 && git push origin v0.1.0`.
+4. The workflow validates that the tag matches the version, builds the artifacts, and uploads them to the corresponding Release.
+
 ## License
 
 MIT © Sebastián de la Fuente


### PR DESCRIPTION
## Summary
- New `.github/workflows/release.yml` publishes a GitHub Release on every `v*` tag push
- Verifies the tag matches `pyproject.toml::project.version` before building (fails loudly on mismatch)
- Uploads the hatchling-built wheel + sdist as release assets via `softprops/action-gh-release@v2`
- README documents the release flow (bump → commit → tag → push)

Closes BEC-12

## Test plan
- [x] YAML syntax validated locally
- [x] Local CI green (ruff check/format, pytest, pyright)
- [ ] End-to-end: after merge, tag `v0.1.0`, push, confirm Release is created with wheel+sdist attached and `pip install <wheel-url>` works

🤖 Generated with [Claude Code](https://claude.com/claude-code)