### PR TITLE
refactor: add pydantic and create models.py alongside TypedDicts (BEC-21)

### DIFF
--- a/matriz_client/models.py
+++ b/matriz_client/models.py
@@ -1,0 +1,271 @@
+"""Pydantic models mirroring the TypedDicts in :mod:`matriz_client.types`.
+
+Introduced in BEC-21 as a side-by-side alternative. The REST/WebSocket
+clients still return TypedDicts at this stage; a follow-up ticket switches
+them over.
+
+Conventions:
+
+* Field names stay in camelCase to match the wire format exactly. A later
+  ticket may introduce snake_case aliases.
+* ``ConfigDict(extra="ignore", populate_by_name=True, frozen=True)`` —
+  tolerant to new fields from the API, immutable once constructed.
+* Optional fields (i.e. those corresponding to ``total=False`` TypedDicts
+  or ``NotRequired`` entries) default to ``None``.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict
+
+from .types import (
+    CFICode,
+    Currency,
+    MarketId,
+    OrderStatus,
+    OrderType,
+    SegmentId,
+    Side,
+    TimeInForce,
+)
+
+__all__ = [
+    "AccountId",
+    "AccountReport",
+    "DetailedPosition",
+    "Instrument",
+    "InstrumentDetail",
+    "InstrumentId",
+    "MarketDataEntryValue",
+    "MarketDataLevel",
+    "MarketDataSnapshot",
+    "NewOrderResponse",
+    "Order",
+    "OrderReport",
+    "Position",
+    "Segment",
+    "Trade",
+]
+
+
+class _PrimaryModel(BaseModel):
+    """Shared config for every Primary API response model."""
+
+    model_config = ConfigDict(
+        extra="ignore",
+        populate_by_name=True,
+        frozen=True,
+    )
+
+
+# ----------------------------------------------------------------------
+# Identifiers
+# ----------------------------------------------------------------------
+
+
+class InstrumentId(_PrimaryModel):
+    """Canonical identifier for an instrument (§5.1)."""
+
+    marketId: MarketId
+    symbol: str
+
+
+class AccountId(_PrimaryModel):
+    """Account wrapper used by WebSocket subscriptions (§7.1)."""
+
+    id: str
+
+
+# ----------------------------------------------------------------------
+# Segments and instruments
+# ----------------------------------------------------------------------
+
+
+class Segment(_PrimaryModel):
+    """Market segment descriptor (§4.1)."""
+
+    marketSegmentId: SegmentId
+    marketId: MarketId
+
+
+class Instrument(_PrimaryModel):
+    """Instrument header returned by list endpoints (§5.1)."""
+
+    instrumentId: InstrumentId
+    cficode: CFICode
+
+
+class InstrumentDetail(_PrimaryModel):
+    """Full instrument detail (§5.2).
+
+    All fields are optional because the Primary API omits entries
+    depending on the instrument's segment and CFI code (mirror of the
+    ``TypedDict(total=False)`` in :mod:`matriz_client.types`).
+    """
+
+    instrumentId: InstrumentId | None = None
+    cficode: CFICode | None = None
+    segment: Segment | None = None
+    lowLimitPrice: float | None = None
+    highLimitPrice: float | None = None
+    minPriceIncrement: float | None = None
+    minTradeVol: float | None = None
+    maxTradeVol: float | None = None
+    tickSize: float | None = None
+    contractMultiplier: float | None = None
+    roundLot: float | None = None
+    priceConvertionFactor: float | None = None
+    maturityDate: str | None = None
+    currency: Currency | None = None
+    orderTypes: list[OrderType] | None = None
+    timesInForce: list[TimeInForce] | None = None
+    instrumentPricePrecision: int | None = None
+    instrumentSizePrecision: int | None = None
+    securityDescription: str | None = None
+    tickPriceRanges: dict[str, Any] | None = None
+
+
+# ----------------------------------------------------------------------
+# Orders
+# ----------------------------------------------------------------------
+
+
+class NewOrderResponse(_PrimaryModel):
+    """Identifiers returned by ``newSingleOrder`` / ``replaceById`` / ``cancelById`` (§6.3)."""
+
+    clientId: str
+    proprietary: str
+
+
+class Order(_PrimaryModel):
+    """Single order status record (§6.8).
+
+    ``orderId`` is nullable because it is only assigned once the order is
+    accepted by the exchange (§13).
+    """
+
+    orderId: str | None = None
+    clOrdId: str
+    proprietary: str
+    execId: str
+    accountId: str
+    instrumentId: InstrumentId
+    price: float
+    orderQty: float
+    ordType: OrderType
+    side: Side
+    timeInForce: TimeInForce
+    transactTime: str
+    avgPx: float
+    lastPx: float
+    lastQty: float
+    cumQty: float
+    leavesQty: float
+    status: OrderStatus
+    text: str
+
+
+class OrderReport(Order):
+    """Execution report (§7.5) — superset of :class:`Order`."""
+
+    wsClOrdId: str | None = None
+
+
+# ----------------------------------------------------------------------
+# Market data
+# ----------------------------------------------------------------------
+
+
+class MarketDataLevel(_PrimaryModel):
+    """Price level inside an order-book entry (``BI`` / ``OF``)."""
+
+    price: float
+    size: int
+
+
+class MarketDataEntryValue(_PrimaryModel):
+    """Scalar market-data entry (``LA``, ``SE``, ``OI`` …) per §8.1."""
+
+    price: float | None = None
+    size: int | None = None
+    date: int | None = None
+
+
+class MarketDataSnapshot(_PrimaryModel):
+    """Market-data response (§8.1).
+
+    Each key is optional; its presence matches the ``entries`` requested
+    by the caller.
+    """
+
+    BI: list[MarketDataLevel] | None = None
+    OF: list[MarketDataLevel] | None = None
+    LA: MarketDataEntryValue | None = None
+    SE: MarketDataEntryValue | None = None
+    OI: MarketDataEntryValue | None = None
+    OP: float | None = None
+    CL: float | None = None
+    HI: float | None = None
+    LO: float | None = None
+    TV: float | None = None
+    IV: float | None = None
+    EV: float | None = None
+    NV: float | None = None
+    ACP: float | None = None
+
+
+class Trade(_PrimaryModel):
+    """Historical trade record (§8.4)."""
+
+    symbol: str
+    servertime: int
+    size: int
+    price: float
+    datetime: str
+
+
+# ----------------------------------------------------------------------
+# Risk API
+# ----------------------------------------------------------------------
+
+
+class Position(_PrimaryModel):
+    """Aggregated position per symbol for an account (§9.1)."""
+
+    symbol: str
+    buySize: float
+    buyPrice: float
+    sellSize: float
+    sellPrice: float
+    totalDailyDiff: float
+    totalDiff: float
+    tradingSymbol: str
+
+
+class DetailedPosition(_PrimaryModel):
+    """Detailed position aggregated per account (§9.2)."""
+
+    account: str | None = None
+    totalDailyDiffPlain: float | None = None
+    totalMarketValue: float | None = None
+    report: dict[str, Any] | None = None
+    lastCalculation: str | None = None
+
+
+class AccountReport(_PrimaryModel):
+    """Full account report with cash, margins and portfolio (§9.3)."""
+
+    accountName: str | None = None
+    marketMember: str | None = None
+    marketMemberIdentity: str | None = None
+    collateral: float | None = None
+    margin: float | None = None
+    availableToCollateral: float | None = None
+    detailedAccountReports: dict[str, Any] | None = None
+    portfolio: dict[str, Any] | None = None
+    ordersMargin: float | None = None
+    currentCash: float | None = None
+    dailyDiff: float | None = None
+    uncoveredMargin: float | None = None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ classifiers = [
     "Typing :: Typed",
 ]
 dependencies = [
+    "pydantic>=2.7",
     "python-dotenv>=1.2.2",
     "requests>=2.32.5",
     "websocket-client>=1.8.0",
@@ -104,6 +105,10 @@ select = [
 ignore = [
     "E501",  # line too long (handled by formatter)
 ]
+
+[tool.ruff.lint.per-file-ignores]
+# Pydantic models mirror the Primary API wire format (camelCase) verbatim.
+"matriz_client/models.py" = ["N815"]
 
 [tool.ruff.format]
 quote-style = "double"

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,0 +1,243 @@
+"""Round-trip tests for :mod:`matriz_client.models` against spec payloads.
+
+Payloads are hand-derived from the examples in ``primary_api_llm.md``. The
+goal is to validate that the Pydantic models match the wire format and
+that our ``extra="ignore"`` / ``frozen=True`` config behaves as expected.
+"""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from matriz_client.models import (
+    AccountReport,
+    DetailedPosition,
+    Instrument,
+    InstrumentDetail,
+    InstrumentId,
+    MarketDataEntryValue,
+    MarketDataLevel,
+    MarketDataSnapshot,
+    NewOrderResponse,
+    Order,
+    OrderReport,
+    Position,
+    Segment,
+    Trade,
+)
+
+# ----------------------------------------------------------------------
+# Basic identifiers
+# ----------------------------------------------------------------------
+
+
+def test_instrument_id_round_trip() -> None:
+    data = {"marketId": "ROFX", "symbol": "DLR/DIC23"}
+    parsed = InstrumentId.model_validate(data)
+    assert parsed.marketId == "ROFX"
+    assert parsed.symbol == "DLR/DIC23"
+    assert parsed.model_dump() == data
+
+
+def test_segment_round_trip() -> None:
+    data = {"marketSegmentId": "DDF", "marketId": "ROFX"}
+    parsed = Segment.model_validate(data)
+    assert parsed.marketSegmentId == "DDF"
+    assert parsed.marketId == "ROFX"
+
+
+def test_instrument_round_trip() -> None:
+    data = {
+        "instrumentId": {"marketId": "ROFX", "symbol": "DLR/DIC23"},
+        "cficode": "FXXXSX",
+    }
+    parsed = Instrument.model_validate(data)
+    assert parsed.instrumentId.symbol == "DLR/DIC23"
+    assert parsed.cficode == "FXXXSX"
+
+
+def test_instrument_detail_accepts_partial_payload() -> None:
+    # InstrumentDetail is the Pydantic equivalent of TypedDict(total=False),
+    # so an empty dict must parse successfully.
+    detail = InstrumentDetail.model_validate({})
+    assert detail.instrumentId is None
+    assert detail.currency is None
+
+
+# ----------------------------------------------------------------------
+# Orders
+# ----------------------------------------------------------------------
+
+
+def test_new_order_response_round_trip() -> None:
+    data = {"clientId": "1-1234", "proprietary": "PBCP"}
+    parsed = NewOrderResponse.model_validate(data)
+    assert parsed.clientId == "1-1234"
+    assert parsed.proprietary == "PBCP"
+
+
+ORDER_PAYLOAD = {
+    "orderId": "218681",
+    "clOrdId": "1-1234",
+    "proprietary": "PBCP",
+    "execId": "1669995044232",
+    "accountId": "REM6771",
+    "instrumentId": {"marketId": "ROFX", "symbol": "DLR/DIC23"},
+    "price": 210.5,
+    "orderQty": 10,
+    "ordType": "LIMIT",
+    "side": "BUY",
+    "timeInForce": "DAY",
+    "transactTime": "20230101-18:19:15.123-0300",
+    "avgPx": 0.0,
+    "lastPx": 0.0,
+    "lastQty": 0,
+    "cumQty": 0,
+    "leavesQty": 10,
+    "status": "NEW",
+    "text": "",
+}
+
+
+def test_order_round_trip() -> None:
+    parsed = Order.model_validate(ORDER_PAYLOAD)
+    assert parsed.orderId == "218681"
+    assert parsed.side == "BUY"
+    assert parsed.instrumentId.symbol == "DLR/DIC23"
+
+
+def test_order_accepts_null_order_id() -> None:
+    # In pre-accept states (e.g. PENDING_NEW) the exchange returns orderId=null.
+    payload = {**ORDER_PAYLOAD, "orderId": None, "status": "PENDING_NEW"}
+    parsed = Order.model_validate(payload)
+    assert parsed.orderId is None
+
+
+def test_order_report_superset_of_order() -> None:
+    report = OrderReport.model_validate({**ORDER_PAYLOAD, "wsClOrdId": "ws-abc"})
+    assert report.wsClOrdId == "ws-abc"
+
+
+# ----------------------------------------------------------------------
+# Market data
+# ----------------------------------------------------------------------
+
+
+def test_market_data_level_round_trip() -> None:
+    parsed = MarketDataLevel.model_validate({"price": 179.8, "size": 1000})
+    assert parsed.price == 179.8
+    assert parsed.size == 1000
+
+
+def test_market_data_entry_value_allows_nulls() -> None:
+    parsed = MarketDataEntryValue.model_validate(
+        {"price": None, "size": 217596, "date": 1664150400000}
+    )
+    assert parsed.price is None
+    assert parsed.size == 217596
+
+
+def test_market_data_snapshot_from_spec_example() -> None:
+    # Based on §8.1. ``CL`` in the live example is an object, but the
+    # TypedDict declares it as a scalar — mirrored here. Tests use only
+    # the fields that match the current type surface.
+    payload = {
+        "SE": {"price": 180.3, "size": None, "date": 1669852800000},
+        "LA": {"price": 179.85, "size": 4, "date": 1669995044232},
+        "OI": {"price": None, "size": 217596, "date": 1664150400000},
+        "OF": [
+            {"price": 179.8, "size": 1000},
+            {"price": 180.35, "size": 1000},
+        ],
+        "OP": 180.35,
+        "BI": [
+            {"price": 179.75, "size": 275},
+            {"price": 178.95, "size": 514},
+        ],
+    }
+    parsed = MarketDataSnapshot.model_validate(payload)
+    assert parsed.OP == 180.35
+    assert parsed.BI is not None
+    assert parsed.BI[0].price == 179.75
+    assert parsed.SE is not None
+    assert parsed.SE.size is None
+
+
+def test_market_data_snapshot_accepts_empty_payload() -> None:
+    parsed = MarketDataSnapshot.model_validate({})
+    assert parsed.BI is None
+    assert parsed.OP is None
+
+
+# ----------------------------------------------------------------------
+# Trades, Risk
+# ----------------------------------------------------------------------
+
+
+def test_trade_round_trip() -> None:
+    parsed = Trade.model_validate(
+        {
+            "symbol": "DLR/DIC23",
+            "servertime": 1669995044232,
+            "size": 4,
+            "price": 179.85,
+            "datetime": "2022-12-02T18:20:44.232-03:00",
+        }
+    )
+    assert parsed.price == 179.85
+
+
+def test_position_round_trip() -> None:
+    parsed = Position.model_validate(
+        {
+            "symbol": "DLR/DIC23",
+            "buySize": 10.0,
+            "buyPrice": 210.5,
+            "sellSize": 0.0,
+            "sellPrice": 0.0,
+            "totalDailyDiff": 0.0,
+            "totalDiff": 0.0,
+            "tradingSymbol": "DLR/DIC23",
+        }
+    )
+    assert parsed.symbol == "DLR/DIC23"
+
+
+def test_detailed_position_accepts_partial_payload() -> None:
+    parsed = DetailedPosition.model_validate({"account": "REM6771"})
+    assert parsed.account == "REM6771"
+    assert parsed.report is None
+
+
+def test_account_report_accepts_partial_payload() -> None:
+    parsed = AccountReport.model_validate(
+        {"accountName": "REM6771", "collateral": 1000.0, "margin": 250.0}
+    )
+    assert parsed.accountName == "REM6771"
+    assert parsed.portfolio is None
+
+
+# ----------------------------------------------------------------------
+# Config behavior
+# ----------------------------------------------------------------------
+
+
+def test_extra_fields_are_ignored() -> None:
+    # Forward-compat: API can add fields without breaking the client.
+    parsed = NewOrderResponse.model_validate(
+        {"clientId": "1-1234", "proprietary": "PBCP", "newField": "future"}
+    )
+    assert parsed.clientId == "1-1234"
+    assert not hasattr(parsed, "newField")
+
+
+def test_models_are_frozen() -> None:
+    parsed = NewOrderResponse.model_validate({"clientId": "1-1234", "proprietary": "PBCP"})
+    with pytest.raises(ValidationError):
+        parsed.clientId = "mutated"  # type: ignore[misc]
+
+
+def test_missing_required_field_raises() -> None:
+    with pytest.raises(ValidationError):
+        NewOrderResponse.model_validate({"clientId": "only"})

--- a/uv.lock
+++ b/uv.lock
@@ -3,6 +3,15 @@ revision = 3
 requires-python = ">=3.12"
 
 [[package]]
+name = "annotated-types"
+version = "0.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ee/67/531ea369ba64dcff5ec9c3402f9f51bf748cec26dde048a2f973a4eea7f5/annotated_types-0.7.0.tar.gz", hash = "sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89", size = 16081, upload-time = "2024-05-20T21:33:25.928Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl", hash = "sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53", size = 13643, upload-time = "2024-05-20T21:33:24.1Z" },
+]
+
+[[package]]
 name = "certifi"
 version = "2026.2.25"
 source = { registry = "https://pypi.org/simple" }
@@ -100,6 +109,7 @@ name = "matriz-client"
 version = "0.1.0"
 source = { editable = "." }
 dependencies = [
+    { name = "pydantic" },
     { name = "python-dotenv" },
     { name = "requests" },
     { name = "websocket-client" },
@@ -114,6 +124,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "pydantic", specifier = ">=2.7" },
     { name = "python-dotenv", specifier = ">=1.2.2" },
     { name = "requests", specifier = ">=2.32.5" },
     { name = "websocket-client", specifier = ">=1.8.0" },
@@ -151,6 +162,96 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "pydantic"
+version = "2.13.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-types" },
+    { name = "pydantic-core" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/09/e5/06d23afac9973109d1e3c8ad38e1547a12e860610e327c05ee686827dc37/pydantic-2.13.2.tar.gz", hash = "sha256:b418196607e61081c3226dcd4f0672f2a194828abb9109e9cfb84026564df2d1", size = 843836, upload-time = "2026-04-17T09:31:59.636Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/77/ca/b45c378e6e8d0b90577288b533e04e95b7afd61bb1d51b6c263176435489/pydantic-2.13.2-py3-none-any.whl", hash = "sha256:a525087f4c03d7e7456a3de89b64cd693d2229933bb1068b9af6befd5563694e", size = 471947, upload-time = "2026-04-17T09:31:57.541Z" },
+]
+
+[[package]]
+name = "pydantic-core"
+version = "2.46.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/43/bb/4742f05b739b2478459bb16fa8470549518c802e06ddcf3f106c5081315e/pydantic_core-2.46.2.tar.gz", hash = "sha256:37bb079f9ee3f1a519392b73fda2a96379b31f2013c6b467fe693e7f2987f596", size = 471269, upload-time = "2026-04-17T09:10:07.017Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/97/ec/2fafa4c86f5d2a69372c7cddef30925fd0e370b1efaf556609c1a0196d8a/pydantic_core-2.46.2-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:ea1ad8c89da31512fe2d249cf0638fb666925bda341901541bc5f3311c6fcc9e", size = 2101729, upload-time = "2026-04-17T09:12:30.042Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/55/be5386c2c4b49af346e8a26b748194ff25757bbb6cf544130854e997af7a/pydantic_core-2.46.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:b308da17b92481e0587244631c5529e5d91d04cb2b08194825627b1eca28e21e", size = 1951546, upload-time = "2026-04-17T09:10:10.585Z" },
+    { url = "https://files.pythonhosted.org/packages/29/92/89e273a055ce440e6636c756379af35ad86da9d336a560049c3ba5e41c80/pydantic_core-2.46.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d333a50bdd814a917d8d6a7ee35ba2395d53ddaa882613bc24e54a9d8b129095", size = 1976178, upload-time = "2026-04-17T09:11:49.619Z" },
+    { url = "https://files.pythonhosted.org/packages/91/b3/e4664469cf70c0cb0f7b2f5719d64e5968bb6f38217042c2afa3d3c4ba17/pydantic_core-2.46.2-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:1d00b99590c5bd1fabbc5d28b170923e32c1b1071b1f1de1851a4d14d89eb192", size = 2051697, upload-time = "2026-04-17T09:12:04.917Z" },
+    { url = "https://files.pythonhosted.org/packages/98/58/dbf68213ee06ce51cdd6d8c95f97980e646858c45bd96bd2dfb40433be73/pydantic_core-2.46.2-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9f0e686960ffe9e65066395af856ac2d52c159043144433602c50c221d81c1ba", size = 2233160, upload-time = "2026-04-17T09:12:00.956Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/d3/68092aa0ee6c60ff4de4740eb82db3d4ce338ec89b3cecb978c532472f12/pydantic_core-2.46.2-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2d1128da41c9cb474e0a4701f9c363ec645c9d1a02229904c76bf4e0a194fde2", size = 2298398, upload-time = "2026-04-17T09:10:29.694Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/51/5d6155eb737db55b0ad354ca5f333ef009f75feb67df2d79a84bace45af6/pydantic_core-2.46.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:48649cf2d8c358d79586e9fb2f8235902fcaa2d969ec1c5301f2d1873b2f8321", size = 2094058, upload-time = "2026-04-17T09:12:10.995Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/f3/eb4a986197d71319430464ff181226c95adc8f06d932189b158bae5a82f5/pydantic_core-2.46.2-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:b902f0fc7c2cf503865a05718b68147c6cd5d0a3867af38c527be574a9fa6e9d", size = 2130388, upload-time = "2026-04-17T09:12:41.159Z" },
+    { url = "https://files.pythonhosted.org/packages/56/00/44a9c4fe6d0f64b5786d6a8c649d6f0e34ba6c89b3663add1066e54451a2/pydantic_core-2.46.2-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:e80011f808b03d1d87a8f1e76ae3da19a18eb706c823e17981dcf1fae43744fc", size = 2184245, upload-time = "2026-04-17T09:12:36.532Z" },
+    { url = "https://files.pythonhosted.org/packages/78/6b/685b98a834d5e3d1c34a1bde1627525559dd223b75075bc7490cdb24eb33/pydantic_core-2.46.2-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:b839d5c802e31348b949b6473f8190cddbf7d47475856d8ac995a373ee16ec59", size = 2186842, upload-time = "2026-04-17T09:13:04.054Z" },
+    { url = "https://files.pythonhosted.org/packages/22/64/caa2f5a2ac8b6113adaa410ccdf31ba7f54897a6e54cd0d726fc7e780c88/pydantic_core-2.46.2-cp312-cp312-musllinux_1_1_armv7l.whl", hash = "sha256:c6b1064f3f9cf9072e1d59dd2936f9f3b668bec1c37039708c9222db703c0d5b", size = 2336066, upload-time = "2026-04-17T09:12:13.006Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/f9/7d2701bf82945b5b9e7df8347be97ef6a36da2846bfe5b4afec299ffe27b/pydantic_core-2.46.2-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:37a68e6f2ac95578ce3c0564802404b27b24988649616e556c07e77111ed3f1d", size = 2363691, upload-time = "2026-04-17T09:13:42.972Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/65/0dab11574101522941055109419db3cc09db871643dc3fc74e2413215e5b/pydantic_core-2.46.2-cp312-cp312-win32.whl", hash = "sha256:d9ffa75a7ef4b97d6e5e205fabd4304ef01fec09e6f1bdde04b9ad1b07d20289", size = 1958801, upload-time = "2026-04-17T09:11:31.981Z" },
+    { url = "https://files.pythonhosted.org/packages/13/2b/df84baa609c676f6450b8ecad44ea59146c805e3371b7b52443c0899f989/pydantic_core-2.46.2-cp312-cp312-win_amd64.whl", hash = "sha256:0551f2d2ddb68af5a00e26497f8025c538f73ef3cb698f8e5a487042cd2792a8", size = 2072634, upload-time = "2026-04-17T09:11:02.407Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/4e/e1ce8029fc438086a946739bf9d596f70ff470aad4a8345555920618cabe/pydantic_core-2.46.2-cp312-cp312-win_arm64.whl", hash = "sha256:83aef30f106edcc21a6a4cc44b82d3169a1dbe255508db788e778f3c804d3583", size = 2026188, upload-time = "2026-04-17T09:13:11.083Z" },
+    { url = "https://files.pythonhosted.org/packages/07/2b/662e48254479a2d3450ba24b1e25061108b64339794232f503990c519144/pydantic_core-2.46.2-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:d26e9eea3715008a09a74585fe9becd0c67fbb145dc4df9756d597d7230a652c", size = 2101762, upload-time = "2026-04-17T09:10:13.87Z" },
+    { url = "https://files.pythonhosted.org/packages/73/ab/bafd7c7503757ccc8ec4d1911e106fe474c629443648c51a88f08b0fe91a/pydantic_core-2.46.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:48b36e3235140510dc7861f0cd58b714b1cdd3d48f75e10ce52e69866b746f10", size = 1951814, upload-time = "2026-04-17T09:12:25.934Z" },
+    { url = "https://files.pythonhosted.org/packages/92/cc/7549c2d57ba2e9a42caa5861a2d398dbe31c02c6aca783253ace59ce84f8/pydantic_core-2.46.2-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:36b1f99dc451f1a3981f236151465bcf995bbe712d0727c9f7b236fe228a8133", size = 1977329, upload-time = "2026-04-17T09:13:37.605Z" },
+    { url = "https://files.pythonhosted.org/packages/18/50/7ed4a8a0d478a4dca8f0134a5efa7193f03cc8520dd4c9509339fb2e5002/pydantic_core-2.46.2-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:8641c8d535c2d95b45c2e19b646ecd23ebba35d461e0ae48a3498277006250ab", size = 2051832, upload-time = "2026-04-17T09:12:49.771Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/16/bb35b193741c0298ddc5f5e4234269efdc0c65e2bcd198aa0de9b68845e4/pydantic_core-2.46.2-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:20fb194788a0a50993e87013e693494ba183a2af5b44e99cf060bbae10912b11", size = 2233127, upload-time = "2026-04-17T09:11:04.449Z" },
+    { url = "https://files.pythonhosted.org/packages/91/a5/98f4b637149185addea19e1785ea20c373cca31b202f589111d8209d9873/pydantic_core-2.46.2-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9262d11d0cd11ee3303a95156939402bed6cedfe5ed0e331b95a283a4da6eb8b", size = 2297418, upload-time = "2026-04-17T09:11:25.929Z" },
+    { url = "https://files.pythonhosted.org/packages/36/90/93a5d21990b152da7b7507b7fddb0b935f6a0984d57ac3ec45a6e17777a2/pydantic_core-2.46.2-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ac204542736aa295fa25f713b7fad6fc50b46ab7764d16087575c85f085174f3", size = 2093735, upload-time = "2026-04-17T09:12:06.908Z" },
+    { url = "https://files.pythonhosted.org/packages/14/22/b8b1ffdddf08b4e84380bcb67f41dbbf4c171377c1d36fc6290794bb2094/pydantic_core-2.46.2-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:9a7c43a0584742dface3ca0daf6f719d46c1ac2f87cf080050f9ae052c75e1b2", size = 2127570, upload-time = "2026-04-17T09:11:53.906Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/26/e60d72b4e2d0ce1fa811044a974412ac1c567fe067d97b3e6b290530786e/pydantic_core-2.46.2-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:fd05e1edb6a90ad446fa268ab09e59202766b837597b714b2492db11ee87fab9", size = 2183524, upload-time = "2026-04-17T09:11:30.092Z" },
+    { url = "https://files.pythonhosted.org/packages/35/32/36bec7584a1eefb17dec4dfa1c946d3fe4440f466c5705b8adfda69c9a9f/pydantic_core-2.46.2-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:91155b110788b5501abc7ea954f1d08606219e4e28e3c73a94124307c06efb80", size = 2185408, upload-time = "2026-04-17T09:10:57.228Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/d6/1a5689d873620efd67d6b163db0c444c056adb0849b5bc33e2b9f09665a6/pydantic_core-2.46.2-cp313-cp313-musllinux_1_1_armv7l.whl", hash = "sha256:e4e2c72a529fa03ff228be1d2b76944013f428220b764e03cc50ada67e17a42c", size = 2335171, upload-time = "2026-04-17T09:11:43.369Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/8e/675104802abe8ef502b072050ee5f2e915251aa1a3af87e1015ce31ec42d/pydantic_core-2.46.2-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:56291ec1a11c3499890c99a8fd9053b47e60fe837a77ec72c0671b1b8b3dce24", size = 2362743, upload-time = "2026-04-17T09:10:18.333Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/bc/86c5dde4fa6e24467680eef5047da3c1a19be0a527d0d8e14aa76b39307c/pydantic_core-2.46.2-cp313-cp313-win32.whl", hash = "sha256:b50f9c5f826ddca1246f055148df939f5f3f2d0d96db73de28e2233f22210d4c", size = 1958074, upload-time = "2026-04-17T09:12:38.622Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/97/2537e8c1282b2c4eb062580c0d7a4339e10b072b803d1ee0b7f1f0a5c22c/pydantic_core-2.46.2-cp313-cp313-win_amd64.whl", hash = "sha256:251a57788823230ca8cbc99e6245d1a2ed6e180ec4864f251c94182c580c7f2e", size = 2071741, upload-time = "2026-04-17T09:13:32.405Z" },
+    { url = "https://files.pythonhosted.org/packages/da/aa/2ee75798706f9dbc4e76dbe59e41a396c5c311e3d6223b9cf6a5fa7780be/pydantic_core-2.46.2-cp313-cp313-win_arm64.whl", hash = "sha256:315d32d1a71494d6b4e1e14a9fa7a4329597b4c4340088ad7e1a9dafbeed92a9", size = 2025955, upload-time = "2026-04-17T09:10:15.567Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/96/a50ccb6b539ae780f73cea74905468777680e30c6c3bdf714b9d4c116ea0/pydantic_core-2.46.2-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:4f59b45f3ef8650c0c736a57f59031d47ed9df4c0a64e83796849d7d14863a2d", size = 2097111, upload-time = "2026-04-17T09:10:49.617Z" },
+    { url = "https://files.pythonhosted.org/packages/34/5f/fdead7b3afa822ab6e5a18ee0ecffd54937de1877c01ed13a342e0fb3f07/pydantic_core-2.46.2-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:3a075a29ebef752784a91532a1a85be6b234ccffec0a9d7978a92696387c3da6", size = 1951904, upload-time = "2026-04-17T09:12:32.062Z" },
+    { url = "https://files.pythonhosted.org/packages/95/e0/1c5d547e550cdab1bec737492aa08865337af6fe7fc9b96f7f45f17d9519/pydantic_core-2.46.2-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0d12d786e30c04a9d307c5d7080bf720d9bac7f1668191d8e37633a9562749e2", size = 1978667, upload-time = "2026-04-17T09:11:35.589Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/cb/665ce629e218c8228302cb94beff4f6531082a2c87d3ecc3d5e63a26f392/pydantic_core-2.46.2-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:0d5e6d6343b0b5dcacb3503b5de90022968da8ed0ab9ab39d3eda71c20cbf84e", size = 2046721, upload-time = "2026-04-17T09:11:47.725Z" },
+    { url = "https://files.pythonhosted.org/packages/77/e9/6cb2cf60f54c1472bbdfce19d957553b43dbba79d1d7b2930a195c594785/pydantic_core-2.46.2-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:233eebac0999b6b9ba76eb56f3ec8fce13164aa16b6d2225a36a79e0f95b5973", size = 2228483, upload-time = "2026-04-17T09:12:08.837Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/2a/93e018dd5571f781ebaeda8c0cf65398489d5bee9b1f484df0b6149b43b9/pydantic_core-2.46.2-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9cc0eee720dd2f14f3b7c349469402b99ad81a174ab49d3533974529e9d93992", size = 2294663, upload-time = "2026-04-17T09:12:52.053Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/4f/49e57ca55c770c93d9bb046666a54949b42e3c9099a0c5fe94557873fe30/pydantic_core-2.46.2-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:83ee76bf2c9910513dbc19e7d82367131fa7508dedd6186a462393071cc11059", size = 2098742, upload-time = "2026-04-17T09:13:45.472Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/b0/6e46b5cd3332af665f794b8cdeea206618a8630bd9e7bcc36864518fce81/pydantic_core-2.46.2-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:d61db38eb4ee5192f0c261b7f2d38e420b554df8912245e3546aee5c45e2fd78", size = 2125922, upload-time = "2026-04-17T09:12:54.304Z" },
+    { url = "https://files.pythonhosted.org/packages/06/d1/40850c81585be443a2abfdf7f795f8fae831baf8e2f9b2133c8246ac671c/pydantic_core-2.46.2-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:8f09a713d17bcd55da8ab02ebd9110c5246a49c44182af213b5212800af8bc83", size = 2183000, upload-time = "2026-04-17T09:10:59.027Z" },
+    { url = "https://files.pythonhosted.org/packages/04/af/8493d7dfa03ebb7866909e577c6aa65ea0de7377b86023cc51d0c8e11db3/pydantic_core-2.46.2-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:30cacc5fb696e64b8ef6fd31d9549d394dd7d52760db072eecb98e37e3af1677", size = 2180335, upload-time = "2026-04-17T09:12:57.01Z" },
+    { url = "https://files.pythonhosted.org/packages/72/5b/1f6a344c4ffdf284da41c6067b82d5ebcbd11ce1b515ae4b662d4adb6f61/pydantic_core-2.46.2-cp314-cp314-musllinux_1_1_armv7l.whl", hash = "sha256:7ccfb105fcfe91a22bbb5563ad3dc124bc1aa75bfd2e53a780ab05f78cdf6108", size = 2330002, upload-time = "2026-04-17T09:12:02.958Z" },
+    { url = "https://files.pythonhosted.org/packages/25/ff/9a694126c12d6d2f48a0cafa6f8eef88ef0d8825600e18d03ff2e896c3b2/pydantic_core-2.46.2-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:13ffef637dc8370c249e5b26bd18e9a80a4fca3d809618c44e18ec834a7ca7a8", size = 2359920, upload-time = "2026-04-17T09:10:27.764Z" },
+    { url = "https://files.pythonhosted.org/packages/51/c8/3a35c763d68a9cb2675eb10ef242cf66c5d4701b28ae12e688d67d2c180e/pydantic_core-2.46.2-cp314-cp314-win32.whl", hash = "sha256:1b0ab6d756ca2704a938e6c31b53f290c2f9c10d3914235410302a149de1a83e", size = 1953701, upload-time = "2026-04-17T09:13:30.021Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/6a/f2726a780365f7dfd89d62036f984f7acb99978c60c5e1fa7c0cb898ed11/pydantic_core-2.46.2-cp314-cp314-win_amd64.whl", hash = "sha256:99ebade8c9ada4df975372d8dd25883daa0e379a05f1cd0c99aa0c04368d01a6", size = 2071867, upload-time = "2026-04-17T09:10:39.205Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/79/76baacb9feba3d7c399b245ca1a29c74ea0db04ea693811374827eec2290/pydantic_core-2.46.2-cp314-cp314-win_arm64.whl", hash = "sha256:de87422197cf7f83db91d89c86a21660d749b3cd76cd8a45d115b8e675670f02", size = 2017252, upload-time = "2026-04-17T09:10:26.175Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/3b/77c26938f817668d9ad9bab1a905cb23f11d9a3d4bf724d429b3e55a8eaf/pydantic_core-2.46.2-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:236f22b4a206b5b61db955396b7cf9e2e1ff77f372efe9570128ccfcd6a525eb", size = 2094545, upload-time = "2026-04-17T09:12:19.339Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/de/42c13f590e3c260966aa49bcdb1674774f975467c49abd51191e502bea28/pydantic_core-2.46.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:c2012f64d2cd7cca50f49f22445aa5a88691ac2b4498ee0a9a977f8ca4f7289f", size = 1933953, upload-time = "2026-04-17T09:09:55.889Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/84/ebe3ebb3e2d8db656937cfa6f97f544cb7132f2307a4a7dfdcd0ea102a12/pydantic_core-2.46.2-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d07d6c63106d3a9c9a333e2636f9c82c703b1a9e3b079299e58747964e4fdb72", size = 1974435, upload-time = "2026-04-17T09:10:12.371Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/15/0bf51ca6709477cd4ef86148b6d7844f3308f029eac361dd0383f1e17b1a/pydantic_core-2.46.2-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:c326a2b4b85e959d9a1fc3a11f32f84611b6ec07c053e1828a860edf8d068208", size = 2031113, upload-time = "2026-04-17T09:10:00.752Z" },
+    { url = "https://files.pythonhosted.org/packages/02/ae/b7b5af9b79db036d9e61a44c481c17a213dc8fc4b8b71fe6875a72fc778b/pydantic_core-2.46.2-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:ac8a65e798f2462552c00d2e013d532c94d646729dda98458beaf51f9ec7b120", size = 2236325, upload-time = "2026-04-17T09:10:33.227Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/ae/ecef7477b5a03d4a499708f7e75d2836452ebb70b776c2d64612b334f57a/pydantic_core-2.46.2-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:5a3c2bc1cc8164bedbc160b7bb1e8cc1e8b9c27f69ae4f9ae2b976cdae02b2dd", size = 2278135, upload-time = "2026-04-17T09:10:23.287Z" },
+    { url = "https://files.pythonhosted.org/packages/db/e4/2f9d82faa47af6c39fc3f120145fd915971e1e0cb6b55b494fad9fdf8275/pydantic_core-2.46.2-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e69aa5e10b7e8b1bb4a6888650fd12fcbf11d396ca11d4a44de1450875702830", size = 2109071, upload-time = "2026-04-17T09:11:06.149Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/9c/677cf10873fbd0b116575ab7b97c90482b21564f8a8040beb18edef7a577/pydantic_core-2.46.2-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:4e6df5c3301e65fb42bc5338bf9a1027a02b0a31dc7f54c33775229af474daf0", size = 2106028, upload-time = "2026-04-17T09:10:51.525Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/53/6a06183544daba51c059123a2064a99039df25f115a06bdb26f2ea177038/pydantic_core-2.46.2-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:2c2f6e32548ac8d559b47944effcf8ae4d81c161f6b6c885edc53bc08b8f192d", size = 2164816, upload-time = "2026-04-17T09:11:56.187Z" },
+    { url = "https://files.pythonhosted.org/packages/57/6f/10fcdd9e3eca66fc828eef0f6f5850f2dd3bca2c59e6e041fb8bc3da39be/pydantic_core-2.46.2-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:b089a81c58e6ea0485562bbbbbca4f65c0549521606d5ef27fba217aac9b665a", size = 2166130, upload-time = "2026-04-17T09:10:03.804Z" },
+    { url = "https://files.pythonhosted.org/packages/29/83/92d3fd0e0156cad2e3cb5c26de73794af78ac9fa0c22ab666e566dd67061/pydantic_core-2.46.2-cp314-cp314t-musllinux_1_1_armv7l.whl", hash = "sha256:7f700a6d6f64112ae9193709b84303bbab84424ad4b47d0253301aabce9dfc70", size = 2316605, upload-time = "2026-04-17T09:12:45.249Z" },
+    { url = "https://files.pythonhosted.org/packages/97/f1/facffdb970981068219582e499b8d0871ed163ffcc6b347de5c412669e4c/pydantic_core-2.46.2-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:67db6814beaa5fefe91101ec7eb9efda613795767be96f7cf58b1ca8c9ca9972", size = 2358385, upload-time = "2026-04-17T09:09:54.657Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/a1/b8160b2f22b2199467bc68581a4ed380643c16b348a27d6165c6c242d694/pydantic_core-2.46.2-cp314-cp314t-win32.whl", hash = "sha256:32fbc7447be8e3be99bf7869f7066308f16be55b61f9882c2cefc7931f5c7664", size = 1942373, upload-time = "2026-04-17T09:12:59.594Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/90/db89acabe5b150e11d1b59fe3d947dda2ef6abbfef5c82f056ff63802f5d/pydantic_core-2.46.2-cp314-cp314t-win_amd64.whl", hash = "sha256:b317a2b97019c0b95ce99f4f901ae383f40132da6706cdf1731066a73394c25c", size = 2052078, upload-time = "2026-04-17T09:10:19.96Z" },
+    { url = "https://files.pythonhosted.org/packages/97/32/e19b83ceb07a3f1bb21798407790bbc9a31740158fd132b94139cb84e16c/pydantic_core-2.46.2-cp314-cp314t-win_arm64.whl", hash = "sha256:7dcb9d40930dfad7ab6b20bcc6ca9d2b030b0f347a0cd9909b54bd53ead521b1", size = 2016941, upload-time = "2026-04-17T09:12:34.447Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/d2/66c146f421178641bda880b0267c0d57dd84f5fec9ecc8e46be17b480742/pydantic_core-2.46.2-graalpy312-graalpy250_312_native-macosx_10_12_x86_64.whl", hash = "sha256:e9fcabd1857492b5bf16f90258babde50f618f55d046b1309972da2396321ff9", size = 2091621, upload-time = "2026-04-17T09:12:47.501Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/b2/c28419aa9fc8055f4ac8e801d1d11c6357351bfa4321ed9bafab3eb98087/pydantic_core-2.46.2-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:fb3ec2c7f54c07b30d89983ce78dc32c37dd06a972448b8716d609493802d628", size = 1937059, upload-time = "2026-04-17T09:10:53.554Z" },
+    { url = "https://files.pythonhosted.org/packages/30/ce/cd0824a2db213dc17113291b7a09b9b0ccd9fbf97daa4b81548703341baf/pydantic_core-2.46.2-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:130a6c837d819ef33e8c2bf702ed2c3429237ea69807f1140943d6f4bdaf52fa", size = 1997278, upload-time = "2026-04-17T09:12:23.784Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/69/47283fe3c0c967d3e9e9cd6c42b70907610c8a6f8d6e8381f1bb55f8006c/pydantic_core-2.46.2-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c2e25417cec5cd9bddb151e33cb08c50160f317479ecc02b22a95ec18f8fe004", size = 2147096, upload-time = "2026-04-17T09:12:43.124Z" },
 ]
 
 [[package]]
@@ -247,6 +348,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
+]
+
+[[package]]
+name = "typing-inspection"
+version = "0.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Add `pydantic>=2.7` as a runtime dependency
- New `matriz_client/models.py` with `BaseModel` equivalents for every response `TypedDict`
- Shared config: `extra="ignore"`, `populate_by_name=True`, `frozen=True`
- Field names mirror the wire format (camelCase); `N815` per-file-ignored for `models.py`
- 19 new round-trip tests in `tests/test_models.py` derived from `primary_api_llm.md` payloads

Non-breaking — public API (REST/WS client functions) is unchanged; TypedDicts remain. Follow-ups switch the client over (BEC-22 / BEC-23) and replace Literals with StrEnum (BEC-24) before the final cleanup + release (BEC-25).

Closes BEC-21

## Test plan
- [x] `uv run ruff check` / `ruff format --check` pass
- [x] `uv run pytest` — 62 passed (19 new)
- [x] `uv run pyright` — 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)