### PR TITLE
refactor: replace Pydantic models with safe-access dataclasses (BEC-26)

### DIFF
--- a/matriz_client/models.py
+++ b/matriz_client/models.py
@@ -1,24 +1,23 @@
-"""Pydantic models mirroring the TypedDicts in :mod:`matriz_client.types`.
+"""Safe-access models for the Primary API v1.21 client.
 
-Introduced in BEC-21 as a side-by-side alternative. The REST/WebSocket
-clients still return TypedDicts at this stage; a follow-up ticket switches
-them over.
+Each model is a frozen dataclass that exposes the wire payload through
+attribute access with always-defined defaults: missing list keys become
+``[]``, missing nested-model keys become an empty model instance, missing
+scalars become ``None``, missing dicts become ``{}``. Chained access like
+``snapshot.SE.price`` never raises ``KeyError`` or ``AttributeError`` —
+the worst case is a final ``None`` for an absent scalar.
 
-Conventions:
-
-* Field names stay in camelCase to match the wire format exactly. A later
-  ticket may introduce snake_case aliases.
-* ``ConfigDict(extra="ignore", populate_by_name=True, frozen=True)`` —
-  tolerant to new fields from the API, immutable once constructed.
-* Optional fields (i.e. those corresponding to ``total=False`` TypedDicts
-  or ``NotRequired`` entries) default to ``None``.
+Construct an instance from a raw dict via ``Model.from_api(payload)``;
+``Model.empty()`` builds a default instance with all attributes at their
+safe defaults. Instances are frozen to discourage mutation of API
+responses.
 """
 
 from __future__ import annotations
 
-from typing import Any
-
-from pydantic import BaseModel, ConfigDict
+import types
+from dataclasses import dataclass, field, fields
+from typing import Any, ClassVar, Self, Union, get_args, get_origin, get_type_hints
 
 from .types import (
     CFICode,
@@ -50,14 +49,67 @@ __all__ = [
 ]
 
 
-class _PrimaryModel(BaseModel):
-    """Shared config for every Primary API response model."""
+# ----------------------------------------------------------------------
+# Type-hint introspection helpers
+# ----------------------------------------------------------------------
 
-    model_config = ConfigDict(
-        extra="ignore",
-        populate_by_name=True,
-        frozen=True,
-    )
+
+def _strip_optional(tp: Any) -> Any:
+    """Return ``T`` from ``T | None`` / ``Optional[T]``; pass through otherwise."""
+    if get_origin(tp) in (Union, types.UnionType):
+        args = [a for a in get_args(tp) if a is not type(None)]
+        if len(args) == 1:
+            return args[0]
+    return tp
+
+
+def _is_model(tp: Any) -> bool:
+    return isinstance(tp, type) and issubclass(tp, _SafeModel)
+
+
+def _convert(tp: Any, value: Any) -> Any:
+    """Coerce ``value`` to the shape declared by ``tp``, applying safe defaults."""
+    inner = _strip_optional(tp)
+    origin = get_origin(inner)
+
+    if origin is list:
+        items = value if isinstance(value, list) else []
+        (item_tp,) = get_args(inner)
+        if _is_model(item_tp):
+            return [item_tp.from_api(v) for v in items]
+        return list(items)
+
+    if origin is dict:
+        return value if isinstance(value, dict) else {}
+
+    if _is_model(inner):
+        return inner.from_api(value) if isinstance(value, dict) else inner.empty()
+
+    return value
+
+
+# ----------------------------------------------------------------------
+# Base
+# ----------------------------------------------------------------------
+
+
+class _SafeModel:
+    """Mixin providing safe ``from_api``/``empty`` constructors for dataclasses."""
+
+    # Declared so pyright accepts ``cls`` as a dataclass; populated by ``@dataclass``.
+    __dataclass_fields__: ClassVar[dict[str, Any]]
+
+    @classmethod
+    def from_api(cls, data: Any) -> Self:
+        if not isinstance(data, dict):
+            return cls.empty()
+        hints = get_type_hints(cls)
+        return cls(**{f.name: _convert(hints[f.name], data.get(f.name)) for f in fields(cls)})
+
+    @classmethod
+    def empty(cls) -> Self:
+        hints = get_type_hints(cls)
+        return cls(**{f.name: _convert(hints[f.name], None) for f in fields(cls)})
 
 
 # ----------------------------------------------------------------------
@@ -65,17 +117,19 @@ class _PrimaryModel(BaseModel):
 # ----------------------------------------------------------------------
 
 
-class InstrumentId(_PrimaryModel):
+@dataclass(frozen=True)
+class InstrumentId(_SafeModel):
     """Canonical identifier for an instrument (§5.1)."""
 
-    marketId: MarketId
-    symbol: str
+    marketId: MarketId | None = None
+    symbol: str | None = None
 
 
-class AccountId(_PrimaryModel):
+@dataclass(frozen=True)
+class AccountId(_SafeModel):
     """Account wrapper used by WebSocket subscriptions (§7.1)."""
 
-    id: str
+    id: str | None = None
 
 
 # ----------------------------------------------------------------------
@@ -83,31 +137,33 @@ class AccountId(_PrimaryModel):
 # ----------------------------------------------------------------------
 
 
-class Segment(_PrimaryModel):
+@dataclass(frozen=True)
+class Segment(_SafeModel):
     """Market segment descriptor (§4.1)."""
 
-    marketSegmentId: SegmentId
-    marketId: MarketId
+    marketSegmentId: SegmentId | None = None
+    marketId: MarketId | None = None
 
 
-class Instrument(_PrimaryModel):
+@dataclass(frozen=True)
+class Instrument(_SafeModel):
     """Instrument header returned by list endpoints (§5.1)."""
 
-    instrumentId: InstrumentId
-    cficode: CFICode
+    instrumentId: InstrumentId = field(default_factory=InstrumentId.empty)
+    cficode: CFICode | None = None
 
 
-class InstrumentDetail(_PrimaryModel):
+@dataclass(frozen=True)
+class InstrumentDetail(_SafeModel):
     """Full instrument detail (§5.2).
 
-    All fields are optional because the Primary API omits entries
-    depending on the instrument's segment and CFI code (mirror of the
-    ``TypedDict(total=False)`` in :mod:`matriz_client.types`).
+    The Primary API omits many fields depending on segment/CFI; safe defaults
+    keep attribute access non-throwing.
     """
 
-    instrumentId: InstrumentId | None = None
+    instrumentId: InstrumentId = field(default_factory=InstrumentId.empty)
     cficode: CFICode | None = None
-    segment: Segment | None = None
+    segment: Segment = field(default_factory=Segment.empty)
     lowLimitPrice: float | None = None
     highLimitPrice: float | None = None
     minPriceIncrement: float | None = None
@@ -119,12 +175,12 @@ class InstrumentDetail(_PrimaryModel):
     priceConvertionFactor: float | None = None
     maturityDate: str | None = None
     currency: Currency | None = None
-    orderTypes: list[OrderType] | None = None
-    timesInForce: list[TimeInForce] | None = None
+    orderTypes: list[OrderType] = field(default_factory=list)
+    timesInForce: list[TimeInForce] = field(default_factory=list)
     instrumentPricePrecision: int | None = None
     instrumentSizePrecision: int | None = None
     securityDescription: str | None = None
-    tickPriceRanges: dict[str, Any] | None = None
+    tickPriceRanges: dict[str, Any] = field(default_factory=dict)
 
 
 # ----------------------------------------------------------------------
@@ -132,41 +188,43 @@ class InstrumentDetail(_PrimaryModel):
 # ----------------------------------------------------------------------
 
 
-class NewOrderResponse(_PrimaryModel):
+@dataclass(frozen=True)
+class NewOrderResponse(_SafeModel):
     """Identifiers returned by ``newSingleOrder`` / ``replaceById`` / ``cancelById`` (§6.3)."""
 
-    clientId: str
-    proprietary: str
+    clientId: str | None = None
+    proprietary: str | None = None
 
 
-class Order(_PrimaryModel):
+@dataclass(frozen=True)
+class Order(_SafeModel):
     """Single order status record (§6.8).
 
-    ``orderId`` is nullable because it is only assigned once the order is
-    accepted by the exchange (§13).
+    ``orderId`` is ``None`` until the exchange accepts the order (§13).
     """
 
     orderId: str | None = None
-    clOrdId: str
-    proprietary: str
-    execId: str
-    accountId: str
-    instrumentId: InstrumentId
-    price: float
-    orderQty: float
-    ordType: OrderType
-    side: Side
-    timeInForce: TimeInForce
-    transactTime: str
-    avgPx: float
-    lastPx: float
-    lastQty: float
-    cumQty: float
-    leavesQty: float
-    status: OrderStatus
-    text: str
+    clOrdId: str | None = None
+    proprietary: str | None = None
+    execId: str | None = None
+    accountId: str | None = None
+    instrumentId: InstrumentId = field(default_factory=InstrumentId.empty)
+    price: float | None = None
+    orderQty: float | None = None
+    ordType: OrderType | None = None
+    side: Side | None = None
+    timeInForce: TimeInForce | None = None
+    transactTime: str | None = None
+    avgPx: float | None = None
+    lastPx: float | None = None
+    lastQty: float | None = None
+    cumQty: float | None = None
+    leavesQty: float | None = None
+    status: OrderStatus | None = None
+    text: str | None = None
 
 
+@dataclass(frozen=True)
 class OrderReport(Order):
     """Execution report (§7.5) — superset of :class:`Order`."""
 
@@ -178,14 +236,16 @@ class OrderReport(Order):
 # ----------------------------------------------------------------------
 
 
-class MarketDataLevel(_PrimaryModel):
+@dataclass(frozen=True)
+class MarketDataLevel(_SafeModel):
     """Price level inside an order-book entry (``BI`` / ``OF``)."""
 
-    price: float
-    size: int
+    price: float | None = None
+    size: int | None = None
 
 
-class MarketDataEntryValue(_PrimaryModel):
+@dataclass(frozen=True)
+class MarketDataEntryValue(_SafeModel):
     """Scalar market-data entry (``LA``, ``SE``, ``OI`` …) per §8.1."""
 
     price: float | None = None
@@ -193,18 +253,20 @@ class MarketDataEntryValue(_PrimaryModel):
     date: int | None = None
 
 
-class MarketDataSnapshot(_PrimaryModel):
+@dataclass(frozen=True)
+class MarketDataSnapshot(_SafeModel):
     """Market-data response (§8.1).
 
-    Each key is optional; its presence matches the ``entries`` requested
-    by the caller.
+    Each entry is optional in the wire payload; missing entries fall back
+    to safe defaults so chained access (``snapshot.SE.price``) never
+    raises.
     """
 
-    BI: list[MarketDataLevel] | None = None
-    OF: list[MarketDataLevel] | None = None
-    LA: MarketDataEntryValue | None = None
-    SE: MarketDataEntryValue | None = None
-    OI: MarketDataEntryValue | None = None
+    BI: list[MarketDataLevel] = field(default_factory=list)
+    OF: list[MarketDataLevel] = field(default_factory=list)
+    LA: MarketDataEntryValue = field(default_factory=MarketDataEntryValue.empty)
+    SE: MarketDataEntryValue = field(default_factory=MarketDataEntryValue.empty)
+    OI: MarketDataEntryValue = field(default_factory=MarketDataEntryValue.empty)
     OP: float | None = None
     CL: float | None = None
     HI: float | None = None
@@ -216,14 +278,15 @@ class MarketDataSnapshot(_PrimaryModel):
     ACP: float | None = None
 
 
-class Trade(_PrimaryModel):
+@dataclass(frozen=True)
+class Trade(_SafeModel):
     """Historical trade record (§8.4)."""
 
-    symbol: str
-    servertime: int
-    size: int
-    price: float
-    datetime: str
+    symbol: str | None = None
+    servertime: int | None = None
+    size: int | None = None
+    price: float | None = None
+    datetime: str | None = None
 
 
 # ----------------------------------------------------------------------
@@ -231,30 +294,33 @@ class Trade(_PrimaryModel):
 # ----------------------------------------------------------------------
 
 
-class Position(_PrimaryModel):
+@dataclass(frozen=True)
+class Position(_SafeModel):
     """Aggregated position per symbol for an account (§9.1)."""
 
-    symbol: str
-    buySize: float
-    buyPrice: float
-    sellSize: float
-    sellPrice: float
-    totalDailyDiff: float
-    totalDiff: float
-    tradingSymbol: str
+    symbol: str | None = None
+    buySize: float | None = None
+    buyPrice: float | None = None
+    sellSize: float | None = None
+    sellPrice: float | None = None
+    totalDailyDiff: float | None = None
+    totalDiff: float | None = None
+    tradingSymbol: str | None = None
 
 
-class DetailedPosition(_PrimaryModel):
+@dataclass(frozen=True)
+class DetailedPosition(_SafeModel):
     """Detailed position aggregated per account (§9.2)."""
 
     account: str | None = None
     totalDailyDiffPlain: float | None = None
     totalMarketValue: float | None = None
-    report: dict[str, Any] | None = None
+    report: dict[str, Any] = field(default_factory=dict)
     lastCalculation: str | None = None
 
 
-class AccountReport(_PrimaryModel):
+@dataclass(frozen=True)
+class AccountReport(_SafeModel):
     """Full account report with cash, margins and portfolio (§9.3)."""
 
     accountName: str | None = None
@@ -263,8 +329,8 @@ class AccountReport(_PrimaryModel):
     collateral: float | None = None
     margin: float | None = None
     availableToCollateral: float | None = None
-    detailedAccountReports: dict[str, Any] | None = None
-    portfolio: dict[str, Any] | None = None
+    detailedAccountReports: dict[str, Any] = field(default_factory=dict)
+    portfolio: dict[str, Any] = field(default_factory=dict)
     ordersMargin: float | None = None
     currentCash: float | None = None
     dailyDiff: float | None = None

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,14 +1,16 @@
-"""Round-trip tests for :mod:`matriz_client.models` against spec payloads.
+"""Tests for the safe-access models in :mod:`matriz_client.models`.
 
-Payloads are hand-derived from the examples in ``primary_api_llm.md``. The
-goal is to validate that the Pydantic models match the wire format and
-that our ``extra="ignore"`` / ``frozen=True`` config behaves as expected.
+The contract: ``Model.from_api(payload)`` parses any dict (full, partial,
+or empty) without raising; missing keys collapse to safe defaults
+(``[]``, empty model, ``None``, ``{}``) so attribute access on the
+result never raises ``KeyError`` or ``AttributeError``.
 """
 
 from __future__ import annotations
 
+from dataclasses import FrozenInstanceError
+
 import pytest
-from pydantic import ValidationError
 
 from matriz_client.models import (
     AccountReport,
@@ -33,36 +35,34 @@ from matriz_client.models import (
 
 
 def test_instrument_id_round_trip() -> None:
-    data = {"marketId": "ROFX", "symbol": "DLR/DIC23"}
-    parsed = InstrumentId.model_validate(data)
+    parsed = InstrumentId.from_api({"marketId": "ROFX", "symbol": "DLR/DIC23"})
     assert parsed.marketId == "ROFX"
     assert parsed.symbol == "DLR/DIC23"
-    assert parsed.model_dump() == data
 
 
 def test_segment_round_trip() -> None:
-    data = {"marketSegmentId": "DDF", "marketId": "ROFX"}
-    parsed = Segment.model_validate(data)
+    parsed = Segment.from_api({"marketSegmentId": "DDF", "marketId": "ROFX"})
     assert parsed.marketSegmentId == "DDF"
     assert parsed.marketId == "ROFX"
 
 
 def test_instrument_round_trip() -> None:
-    data = {
-        "instrumentId": {"marketId": "ROFX", "symbol": "DLR/DIC23"},
-        "cficode": "FXXXSX",
-    }
-    parsed = Instrument.model_validate(data)
+    parsed = Instrument.from_api(
+        {
+            "instrumentId": {"marketId": "ROFX", "symbol": "DLR/DIC23"},
+            "cficode": "FXXXSX",
+        }
+    )
     assert parsed.instrumentId.symbol == "DLR/DIC23"
     assert parsed.cficode == "FXXXSX"
 
 
 def test_instrument_detail_accepts_partial_payload() -> None:
-    # InstrumentDetail is the Pydantic equivalent of TypedDict(total=False),
-    # so an empty dict must parse successfully.
-    detail = InstrumentDetail.model_validate({})
-    assert detail.instrumentId is None
+    detail = InstrumentDetail.from_api({})
+    assert detail.instrumentId == InstrumentId.empty()
     assert detail.currency is None
+    assert detail.orderTypes == []
+    assert detail.tickPriceRanges == {}
 
 
 # ----------------------------------------------------------------------
@@ -71,8 +71,7 @@ def test_instrument_detail_accepts_partial_payload() -> None:
 
 
 def test_new_order_response_round_trip() -> None:
-    data = {"clientId": "1-1234", "proprietary": "PBCP"}
-    parsed = NewOrderResponse.model_validate(data)
+    parsed = NewOrderResponse.from_api({"clientId": "1-1234", "proprietary": "PBCP"})
     assert parsed.clientId == "1-1234"
     assert parsed.proprietary == "PBCP"
 
@@ -101,22 +100,31 @@ ORDER_PAYLOAD = {
 
 
 def test_order_round_trip() -> None:
-    parsed = Order.model_validate(ORDER_PAYLOAD)
+    parsed = Order.from_api(ORDER_PAYLOAD)
     assert parsed.orderId == "218681"
     assert parsed.side == "BUY"
     assert parsed.instrumentId.symbol == "DLR/DIC23"
 
 
 def test_order_accepts_null_order_id() -> None:
-    # In pre-accept states (e.g. PENDING_NEW) the exchange returns orderId=null.
     payload = {**ORDER_PAYLOAD, "orderId": None, "status": "PENDING_NEW"}
-    parsed = Order.model_validate(payload)
+    parsed = Order.from_api(payload)
     assert parsed.orderId is None
 
 
+def test_order_partial_payload_uses_safe_defaults() -> None:
+    parsed = Order.from_api({"clOrdId": "only"})
+    assert parsed.clOrdId == "only"
+    assert parsed.orderId is None
+    assert parsed.price is None
+    assert parsed.instrumentId == InstrumentId.empty()
+    assert parsed.instrumentId.symbol is None
+
+
 def test_order_report_superset_of_order() -> None:
-    report = OrderReport.model_validate({**ORDER_PAYLOAD, "wsClOrdId": "ws-abc"})
+    report = OrderReport.from_api({**ORDER_PAYLOAD, "wsClOrdId": "ws-abc"})
     assert report.wsClOrdId == "ws-abc"
+    assert report.orderId == "218681"
 
 
 # ----------------------------------------------------------------------
@@ -125,23 +133,18 @@ def test_order_report_superset_of_order() -> None:
 
 
 def test_market_data_level_round_trip() -> None:
-    parsed = MarketDataLevel.model_validate({"price": 179.8, "size": 1000})
+    parsed = MarketDataLevel.from_api({"price": 179.8, "size": 1000})
     assert parsed.price == 179.8
     assert parsed.size == 1000
 
 
 def test_market_data_entry_value_allows_nulls() -> None:
-    parsed = MarketDataEntryValue.model_validate(
-        {"price": None, "size": 217596, "date": 1664150400000}
-    )
+    parsed = MarketDataEntryValue.from_api({"price": None, "size": 217596, "date": 1664150400000})
     assert parsed.price is None
     assert parsed.size == 217596
 
 
 def test_market_data_snapshot_from_spec_example() -> None:
-    # Based on §8.1. ``CL`` in the live example is an object, but the
-    # TypedDict declares it as a scalar — mirrored here. Tests use only
-    # the fields that match the current type surface.
     payload = {
         "SE": {"price": 180.3, "size": None, "date": 1669852800000},
         "LA": {"price": 179.85, "size": 4, "date": 1669995044232},
@@ -156,18 +159,32 @@ def test_market_data_snapshot_from_spec_example() -> None:
             {"price": 178.95, "size": 514},
         ],
     }
-    parsed = MarketDataSnapshot.model_validate(payload)
+    parsed = MarketDataSnapshot.from_api(payload)
     assert parsed.OP == 180.35
-    assert parsed.BI is not None
     assert parsed.BI[0].price == 179.75
-    assert parsed.SE is not None
     assert parsed.SE.size is None
+    assert parsed.SE.price == 180.3
 
 
 def test_market_data_snapshot_accepts_empty_payload() -> None:
-    parsed = MarketDataSnapshot.model_validate({})
-    assert parsed.BI is None
+    parsed = MarketDataSnapshot.from_api({})
+    assert parsed.BI == []
+    assert parsed.OF == []
     assert parsed.OP is None
+    # Nested-model fields default to an empty instance, never None.
+    assert MarketDataEntryValue.empty() == parsed.SE
+    assert parsed.SE.price is None
+
+
+def test_market_data_snapshot_safe_chained_access_on_missing_keys() -> None:
+    """The headline guarantee: chained access never raises on missing keys."""
+    parsed = MarketDataSnapshot.from_api({"OP": 180.0})
+    assert parsed.OP == 180.0
+    # Missing BI iterates as an empty list, not None.
+    assert list(parsed.BI) == []
+    # Missing SE returns an empty MarketDataEntryValue; .price is None.
+    assert parsed.SE.price is None
+    assert parsed.LA.size is None
 
 
 # ----------------------------------------------------------------------
@@ -176,7 +193,7 @@ def test_market_data_snapshot_accepts_empty_payload() -> None:
 
 
 def test_trade_round_trip() -> None:
-    parsed = Trade.model_validate(
+    parsed = Trade.from_api(
         {
             "symbol": "DLR/DIC23",
             "servertime": 1669995044232,
@@ -189,7 +206,7 @@ def test_trade_round_trip() -> None:
 
 
 def test_position_round_trip() -> None:
-    parsed = Position.model_validate(
+    parsed = Position.from_api(
         {
             "symbol": "DLR/DIC23",
             "buySize": 10.0,
@@ -205,17 +222,42 @@ def test_position_round_trip() -> None:
 
 
 def test_detailed_position_accepts_partial_payload() -> None:
-    parsed = DetailedPosition.model_validate({"account": "REM6771"})
+    parsed = DetailedPosition.from_api({"account": "REM6771"})
     assert parsed.account == "REM6771"
-    assert parsed.report is None
+    assert parsed.report == {}
 
 
 def test_account_report_accepts_partial_payload() -> None:
-    parsed = AccountReport.model_validate(
+    parsed = AccountReport.from_api(
         {"accountName": "REM6771", "collateral": 1000.0, "margin": 250.0}
     )
     assert parsed.accountName == "REM6771"
-    assert parsed.portfolio is None
+    assert parsed.portfolio == {}
+    assert parsed.detailedAccountReports == {}
+
+
+# ----------------------------------------------------------------------
+# Constructor edge cases
+# ----------------------------------------------------------------------
+
+
+def test_from_api_with_none_returns_empty() -> None:
+    assert MarketDataSnapshot.from_api(None) == MarketDataSnapshot.empty()
+    assert Order.from_api(None) == Order.empty()
+
+
+def test_from_api_with_non_dict_returns_empty() -> None:
+    # Defensive: if the API ever returns something unexpected, the model
+    # still constructs cleanly instead of raising.
+    assert NewOrderResponse.from_api("garbage") == NewOrderResponse.empty()
+    assert NewOrderResponse.from_api(123) == NewOrderResponse.empty()
+
+
+def test_empty_classmethod_produces_default_instance() -> None:
+    snapshot = MarketDataSnapshot.empty()
+    assert snapshot.BI == []
+    assert snapshot.OP is None
+    assert snapshot.SE.price is None
 
 
 # ----------------------------------------------------------------------
@@ -224,8 +266,7 @@ def test_account_report_accepts_partial_payload() -> None:
 
 
 def test_extra_fields_are_ignored() -> None:
-    # Forward-compat: API can add fields without breaking the client.
-    parsed = NewOrderResponse.model_validate(
+    parsed = NewOrderResponse.from_api(
         {"clientId": "1-1234", "proprietary": "PBCP", "newField": "future"}
     )
     assert parsed.clientId == "1-1234"
@@ -233,11 +274,6 @@ def test_extra_fields_are_ignored() -> None:
 
 
 def test_models_are_frozen() -> None:
-    parsed = NewOrderResponse.model_validate({"clientId": "1-1234", "proprietary": "PBCP"})
-    with pytest.raises(ValidationError):
+    parsed = NewOrderResponse.from_api({"clientId": "1-1234", "proprietary": "PBCP"})
+    with pytest.raises(FrozenInstanceError):
         parsed.clientId = "mutated"  # type: ignore[misc]
-
-
-def test_missing_required_field_raises() -> None:
-    with pytest.raises(ValidationError):
-        NewOrderResponse.model_validate({"clientId": "only"})


### PR DESCRIPTION
## Summary

Replaces the Pydantic models added in BEC-21 with a safe-access dataclass layer. Pydantic could raise `ValidationError` mid-flow on unexpected payloads, interrupting normal client execution; the new layer never raises on parsing and never raises on attribute access either.

- New `_SafeModel` mixin over `@dataclass(frozen=True)` introspects type hints and collapses missing keys to safe defaults: lists → `[]`, nested models → empty model instance, scalars → `None`, dicts → `{}`.
- `Model.from_api(payload)` parses any dict (full, partial, empty, or non-dict) without raising; `Model.empty()` builds a default instance.
- Chained access like `snapshot.SE.price` is guaranteed not to raise — worst case is a final `None`.
- Extra wire fields are silently ignored for forward compatibility.
- The REST and WebSocket clients still hand out `dict[str, Any]` at this stage — switching them is BEC-27 / BEC-29.

Linear: BEC-26

## Test plan

- [x] `uv run ruff check . && uv run ruff format --check .`
- [x] `uv run pyright`
- [x] `uv run pytest -v` (66 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)