### PR TITLE
chore: bump matriz_client to 0.2.0 (BEC-30)

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,43 @@ primary.ws_subscribe_market_data(["DLR/DIC23"], depth=5)
 from matriz_client import Side, OrderType, TimeInForce, Order, MarketDataSnapshot
 ```
 
+## Migrating from 0.1.x
+
+`0.2.0` replaces dict-based responses (TypedDicts) with frozen safe-access dataclasses. Field access is by attribute, not subscript:
+
+```python
+# 0.1.x — TypedDict / raw JSON
+md = primary.get_market_data("DLR/DIC23")
+print(md["OP"], md["BI"][0]["price"])     # KeyError if "OP" or "BI" missing
+
+resp = primary.new_order(...)
+print(resp["clientId"])
+
+# 0.2.0 — safe-access dataclasses
+md = primary.get_market_data("DLR/DIC23")
+print(md.OP, md.BI[0].price)              # md.OP can be None, never raises
+print(md.SE.price)                        # nested chain safe even if "SE" missing
+
+resp = primary.new_order(...)
+print(resp.clientId)
+```
+
+WebSocket callbacks now receive a tagged `PrimaryWsMessage` instead of a raw `dict`:
+
+```python
+# 0.1.x
+def on_msg(msg: dict) -> None:
+    if msg["type"] == "Md":
+        print(msg["marketData"]["BI"])
+
+# 0.2.0
+def on_msg(msg: PrimaryWsMessage) -> None:
+    if isinstance(msg, MarketDataFrame):
+        print(msg.marketData.BI)
+```
+
+**Safety guarantee.** Missing keys never raise `KeyError`/`AttributeError`. Lists default to `[]`, nested models to an empty instance, scalars to `None`, dicts to `{}`. Chained access like `snapshot.SE.price` always resolves — the worst case is a final `None`.
+
 ## Reference
 
 - Full Primary API v1.21 spec: [`primary_api_llm.md`](./primary_api_llm.md)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "matriz-client"
-version = "0.1.0"
+version = "0.2.0"
 description = "Python client for the MATBA ROFEX Primary API v1.21 (REST + WebSocket)."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -97,7 +97,7 @@ wheels = [
 
 [[package]]
 name = "matriz-client"
-version = "0.1.0"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "python-dotenv" },


### PR DESCRIPTION
## Summary

- Bump `project.version` to `0.2.0`, closing the safe-access migration cycle (BEC-26..29).
- Add a "Migrating from 0.1.x" section to the README with side-by-side examples of the dict→attribute access shift and the new typed WebSocket callback shape.

## Test plan

- [x] `uv build` produces wheel + sdist (validated with `twine check`).
- [x] `uv run ruff check . && uv run ruff format --check .`
- [x] `uv run pyright` clean
- [x] `uv run pytest` — 69 passed
- [ ] Post-merge: tag `v0.2.0`, verify release workflow publishes the wheel.
- [ ] Smoke: `pip install` published wheel in clean venv, run `python -c "import matriz_client; print(matriz_client.MarketDataSnapshot.empty())"`.

Closes BEC-30.

🤖 Generated with [Claude Code](https://claude.com/claude-code)