### PR TITLE
docs: make vault updates part of ticket DoD

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,9 +70,17 @@ The full Primary API v1.21 specification is in `primary_api_llm.md` (LLM-optimiz
 
 Para issues nuevos, el flujo es:
 
-1. Leer el issue en Linear (via MCP) para entender el contexto
-2. Consultar notas de dominio relevantes en `matriz-vault/` (via obsidian MCP) si aplica
-3. Crear branch con el formato correcto
-4. Implementar, correr Ruff localmente (`uv run ruff check . && uv run ruff format .`)
-5. Commitear y crear PR con link al issue de Linear
-6. Merge → Linear auto-cierra el issue
+1. Leer el issue en Linear (via MCP) para entender el contexto.
+2. Consultar notas relevantes del vault (`matriz-vault/`, via obsidian MCP) — al menos `projects/matriz-client/README.md`, ADRs, runbooks y domain notes que toquen el área.
+3. Crear branch con el formato correcto.
+4. Implementar, correr Ruff localmente (`uv run ruff check . && uv run ruff format .`).
+5. Commitear y crear PR con link al issue de Linear.
+6. Esperar CI verde y mergear (squash). Linear auto-cierra el issue.
+7. **Cierre del ticket — actualizar el vault (paso obligatorio, no opcional).** Antes de pasar al próximo ticket, escribir lo que corresponda usando el `obsidian` MCP. Criterios:
+   - **ADR** en `projects/matriz-client/decisions/` — si introdujiste una decisión arquitectónica nueva, cambiaste una previa, o evaluaste alternativas que vale la pena recordar. Usar `_templates/tpl-adr.md` y numerar correlativo (`ADR-NNN`).
+   - **Runbook** en `projects/matriz-client/runbooks/` — si codificaste un procedimiento operativo que se va a repetir (release, rotación de credenciales, debugging de un endpoint problemático). Usar `_templates/tpl-runbook.md`.
+   - **Domain note** en `projects/matriz-client/domain/` — si descubriste un patrón del dominio (API, mercado, datos) que el código solo no comunica.
+   - **Daily log** del día en `daily-logs/YYYY-MM-DD.md` — siempre, una entrada por ticket cerrado con qué se hizo, aprendizajes, y links a notas creadas/actualizadas. Crear el archivo con `_templates/tpl-daily-log.md` si todavía no existe para hoy.
+   - **`projects/matriz-client/README.md`** — actualizar si la nota nueva debería listarse en Decisiones, Runbooks o Notas de dominio.
+
+   Si **ninguna** de las primeras tres aplica, igualmente registrar el ticket en el daily log con una línea que diga por qué no generó documentación nueva. Cero documentación silenciosa.

--- a/matriz-vault/daily-logs/2026-04-17.md
+++ b/matriz-vault/daily-logs/2026-04-17.md
@@ -1,0 +1,37 @@
+---
+date: 2026-04-17
+tags: [daily]
+---
+
+# Daily Log — 2026-04-17
+
+## Foco del día
+- [x] Cerrar el ciclo de migración safe-access (BEC-26..30)
+- [x] Publicar `v0.2.0`
+
+## Lo que hice
+
+- **BEC-26**: foundation. Mixin `_SafeModel` con `from_api` / `empty` que introspecciona type hints y aplica defaults seguros. Tests unitarios.
+- **BEC-27**: convertí todos los retornos del REST (`client.py`) a `Model.from_api(...)`.
+- **BEC-28**: cleanup. Eliminé los TypedDicts redundantes de `types.py` (quedaron solo Literals + constantes) y actualicé `__init__.py`.
+- **BEC-29**: WS frames. `MarketDataFrame`, `ExecutionReportFrame`, `UnknownFrame` + dispatcher por `type`. Callback ahora recibe `PrimaryWsMessage` en lugar de `dict`.
+- **BEC-30**: bump a `0.2.0`, sección "Migrating from 0.1.x" en el README, tag `v0.2.0` para disparar el release workflow (BEC-12).
+
+Cinco PRs (#44..#49 — alguno de los números intermedios fue de otra tanda) mergeados con squash. Cada uno con CI verde antes de mergear; auto-loop chequeando cada ~2 min y avanzando solo.
+
+## Aprendizajes
+
+- **El vault no se actualiza solo**. Cerré 5 tickets sin escribir una línea de ADR ni de runbook hasta que el usuario lo señaló. A partir de ahora, parte de cerrar un ticket es preguntarme: ¿esto introdujo una decisión arquitectónica? ¿un procedimiento nuevo? ¿un patrón de dominio? Si sí, va al vault.
+- **`UnknownFrame` no debe heredar `_SafeModel`**: necesita preservar el dict crudo, no introspectar fields declarados. Implementar `from_api`/`empty` por duck-typing fue más limpio que forzar el patrón.
+- **Pyright + dataclass mixin**: declarar `__dataclass_fields__: ClassVar[dict[str, Any]]` en el mixin satisface el protocolo sin romper nada — `@dataclass` lo sobrescribe por subclase.
+
+## Notas para mañana
+
+- Verificar que el GitHub Release `v0.2.0` salió bien y hacer el smoke install.
+- Si el ciclo nuevo de tickets vuelve a omitir el vault, revisitar el workflow para volverlo explícito.
+
+## Referencias
+
+- [[ADR-002 — Safe-access dataclasses sobre Pydantic]]
+- [[Wire format y keys opcionales]]
+- [[Cortar un release]]

--- a/matriz-vault/projects/matriz-client/README.md
+++ b/matriz-vault/projects/matriz-client/README.md
@@ -1,12 +1,12 @@
 ---
 tags: [project, fintech, trading]
 status: active
-repo: github.com/[tu-usuario]/matriz-client
+repo: github.com/sebadlf/matriz-client
 ---
 
 # Matriz Client
 
-Cliente Python para la **MATBA ROFEX Primary API v1.21**. Wrappea endpoints REST de trading electrónico en Argentina (derivados y valores).
+Cliente Python para la **MATBA ROFEX Primary API v1.21**. Wrappea endpoints REST + WebSocket de trading electrónico en Argentina (derivados y valores).
 
 ## Links
 
@@ -14,18 +14,28 @@ Cliente Python para la **MATBA ROFEX Primary API v1.21**. Wrappea endpoints REST
 - API spec: `primary_api_llm.md` en el repo
 - Linear team: `Becerra` (prefix `BEC`) — https://linear.app/gravity-code/team/BEC
 - Branch format: `sebadlf-bec-{n}-{descripcion}`
+- Distribución: GitHub Releases (no PyPI), workflow `release.yml` por tag `v*`
 
 ## Estado actual
 
-- Single-module stateful client con globals para auth
-- Sin tests, linter, ni formatter configurado
-- Dependencias: `requests`, `python-dotenv`, `websocket-client`
+- Single-module stateful client con globals para auth (REST + WS).
+- Versión: `0.2.0` — modelos safe-access (dataclasses frozen) reemplazaron Pydantic / TypedDicts.
+- Toolchain: `uv`, `ruff` (lint + format), `pyright` (standard), `pytest`.
+- CI: lint + format + tests + pyright en cada PR.
+- Dependencias: `requests`, `python-dotenv`, `websocket-client`.
 
 ## Decisiones
 
 - [[ADR-001 — GET para todo]] — la API usa GET incluso para orders (no es un bug)
+- [[ADR-002 — Safe-access dataclasses sobre Pydantic]] — por qué `0.2.0` reemplazó la primera iteración Pydantic
 
 ## Notas de dominio
 
 - [[Conceptos Primary API]]
 - [[Segmentos de mercado]]
+- [[Wire format y keys opcionales]] — el patrón de respuestas parciales que motivó safe-access
+
+## Runbooks
+
+- [[Setup desde cero]]
+- [[Cortar un release]] — bump → tag → workflow

--- a/matriz-vault/projects/matriz-client/decisions/ADR-002 — Safe-access dataclasses sobre Pydantic.md
+++ b/matriz-vault/projects/matriz-client/decisions/ADR-002 — Safe-access dataclasses sobre Pydantic.md
@@ -1,0 +1,57 @@
+---
+date: 2026-04-17
+status: accepted
+tags: [adr, api-design, types]
+---
+
+# ADR-002: Safe-access dataclasses como modelo de respuesta
+
+## Contexto
+
+La iteración inicial (BEC-21) introdujo modelos Pydantic para tipar las respuestas de la Primary API. Surgieron dos problemas:
+
+- **Pydantic levanta `ValidationError` en runtime** si la API devuelve un tipo inesperado (p. ej. un string donde se esperaba un float). Eso interrumpe el flujo del cliente cuando lo único que el usuario quería era leer un par de campos.
+- Los **TypedDicts** previos eran tipo solo en estático: en runtime son `dict` planos, así que `md["LA"]["price"]` lanza `KeyError` si la API omite `LA`. La Primary API omite entries con frecuencia (depende del segmento, hora del día, actividad).
+
+Necesitamos un modelo donde el acceso encadenado (`snapshot.SE.price`) **nunca rompa**, aunque la wire payload sea parcial.
+
+## Decisión
+
+Reemplazar Pydantic por `@dataclass(frozen=True)` con un mixin `_SafeModel` que introspecciona type hints y construye instancias con defaults seguros:
+
+- `list[X]` ausente → `[]`
+- modelo anidado ausente → instancia vacía del modelo (todos sus atributos en default)
+- escalar (`float`, `int`, `str`) ausente → `None`
+- `dict[str, Any]` ausente → `{}`
+
+Construcción vía `Model.from_api(payload)`; instancias frozen para desincentivar mutación de respuestas. Todas las funciones del REST y los frames del WS retornan estas clases.
+
+## Alternativas consideradas
+
+### Opción A: Pydantic con `model_validate` y try/except por endpoint
+- Pro: validación real, errores tempranos.
+- Contra: el usuario tiene que envolver cada llamada; inconsistente con la naturaleza "best-effort" de market data parcial.
+
+### Opción B: TypedDicts + `.get()` en cascada
+- Pro: cero runtime overhead.
+- Contra: `md.get("LA", {}).get("price")` es ruidoso y se olvida en un call site cualquiera; tipos no expresan los defaults.
+
+### Opción C: dataclasses + safe defaults (elegida)
+- Pro: chaining seguro por construcción, frozen, atributos en lugar de subscript, sin dependencias extra.
+- Contra: sin validación de tipos en runtime; campos extra de la API se ignoran silenciosamente.
+
+## Consecuencias
+
+- **Breaking change**: `0.1.x` (TypedDict / dict) → `0.2.0` (dataclasses). Documentado en `README.md` sección "Migrating from 0.1.x".
+- Eliminamos `pydantic` del `dependencies`.
+- `extra` keys del API se descartan silenciosamente (forward-compat OK, pero nuevas keys no aparecen hasta declararlas).
+- Sin validación de tipos: si la API devuelve `price: "not a number"`, el modelo lo guarda como string. Detección queda en el lado del usuario / pruebas.
+- `get_type_hints()` y `dataclass.fields()` se invocan por cada `from_api`. Si emerge como hot path (WS market data), cachear hints por clase.
+- `UnknownFrame` no hereda de `_SafeModel`: preserva el dict crudo en `raw` para forward-compat de frames WS no modelados.
+
+## Referencias
+
+- Plan: `~/.claude/plans/foamy-hatching-cook.md`
+- Tickets: BEC-26 (foundation), BEC-27 (REST), BEC-28 (cleanup), BEC-29 (WS), BEC-30 (release v0.2.0)
+- Implementación: `matriz_client/models.py`
+- [[Wire format y keys opcionales]] — el patrón del API que motivó el diseño

--- a/matriz-vault/projects/matriz-client/domain/Wire format y keys opcionales.md
+++ b/matriz-vault/projects/matriz-client/domain/Wire format y keys opcionales.md
@@ -1,0 +1,50 @@
+---
+tags: [domain, api]
+---
+
+# Wire format y keys opcionales
+
+La Primary API v1.21 omite keys con frecuencia en sus respuestas JSON, según segmento, hora del día, actividad del símbolo, o nivel de detalle del endpoint. **No es un bug**: es el contrato. El cliente debe asumir que cualquier key documentada puede no estar presente.
+
+## Patrones observados
+
+### Market Data (§8)
+
+`GET /rest/marketdata/get?marketId=...&symbol=...&entries=BI,OF,LA,SE,OI,...` retorna un dict `marketData` donde cada entry pedida puede aparecer o no:
+
+```json
+{
+  "marketData": {
+    "BI": [{"price": 100.5, "size": 10}],
+    "OF": [],
+    "LA": {"price": 100.3, "size": 5, "date": 1681000000}
+    // SE / OI / OP / CL / HI / LO ausentes si no hay actividad o el segmento no los soporta
+  }
+}
+```
+
+- Los entries de "book" (`BI`, `OF`) cuando ausentes pueden venir como `[]` o no venir directamente.
+- Los entries escalares (`OP`, `CL`, `HI`, `LO`, `TV`) suelen omitirse si el símbolo no tradeó.
+- Los entries con sub-objeto (`LA`, `SE`, `OI`) cuando ausentes simplemente no aparecen.
+
+### Instrumentos (§5.2)
+
+`InstrumentDetail` declara ~18 campos pero la API devuelve un subconjunto distinto por CFI/segmento (los productos sin maturity no traen `maturityDate`, los productos sin opciones no traen `tickPriceRanges`, etc.).
+
+### Execution Reports (§7.5)
+
+`OrderReport` evoluciona durante la vida de la orden: el primer reporte (`PENDING_NEW`) no trae `orderId` todavía; campos como `lastPx` / `lastQty` solo aparecen cuando hay un fill.
+
+### Risk (§9)
+
+`AccountReport.detailedAccountReports` y `portfolio` son dicts opaques cuya estructura depende del market member. Los tipamos como `dict[str, Any]`.
+
+## Implicancia de diseño
+
+Esto motivó [[ADR-002 — Safe-access dataclasses sobre Pydantic]]. El cliente nunca puede asumir que `payload["X"]` existe; el modelo lo absorbe con defaults.
+
+## Cómo agregar un campo nuevo cuando el API lo expone
+
+1. Declararlo en el `@dataclass` del modelo correspondiente (`matriz_client/models.py`) con su tipo y default seguro (`None` para escalar, `field(default_factory=list/dict)` para colecciones, `field(default_factory=NestedModel.empty)` para anidado).
+2. No hace falta tocar `from_api` — el mixin lo descubre vía `get_type_hints`.
+3. Test en `tests/test_models.py`: payload presente y payload sin la key.

--- a/matriz-vault/projects/matriz-client/runbooks/Cortar un release.md
+++ b/matriz-vault/projects/matriz-client/runbooks/Cortar un release.md
@@ -1,0 +1,86 @@
+---
+last_verified: 2026-04-17
+tags: [runbook, release]
+---
+
+# Runbook: Cortar un release de matriz-client
+
+## Cuándo usar
+
+Cuando hay cambios mergeados a `main` listos para publicar como GitHub Release. La distribución va por GitHub Releases (no PyPI). El workflow `.github/workflows/release.yml` (BEC-12) construye y publica wheel + sdist al pushear un tag `v*`.
+
+## Pre-requisitos
+
+- [ ] Permisos de push y de tag en `sebadlf/matriz-client`.
+- [ ] CI verde en `main` para el commit a taggear.
+- [ ] Cambios de breaking que requieran sección "Migrating from X.Y" en el README ya documentados.
+
+## Pasos
+
+### 1. Bumpear versión en `pyproject.toml`
+
+```bash
+# editar manualmente:
+# project.version = "0.X.Y" → "0.X+1.0" (minor) o "0.X.Y+1" (patch)
+uv sync   # regenera uv.lock con la nueva versión del paquete editable
+```
+
+Convención: bumps de breaking change → minor (estamos en `0.x`); bumps de feature aditiva o fix → patch.
+
+### 2. Validar el build localmente
+
+```bash
+uv build
+uv run --with twine twine check dist/*
+```
+
+Ambos checks (`wheel` + `sdist`) deben dar `PASSED`.
+
+### 3. Verificar suite completa
+
+```bash
+uv run ruff check . && uv run ruff format --check . && uv run pyright && uv run pytest -q
+```
+
+### 4. PR a main
+
+Branch `sebadlf-bec-{n}-chore-bump-...`, commit `chore: bump matriz_client to X.Y.Z (BEC-NN)`, PR con checklist. Esperar CI verde y mergear con squash.
+
+### 5. Tag y push
+
+Una vez mergeado, en `main` actualizado:
+
+```bash
+git checkout main && git pull origin main
+git tag vX.Y.Z
+git push origin vX.Y.Z
+```
+
+El workflow `release.yml` se dispara con el push del tag. **Validación interna del workflow**: confirma que el tag matchea `project.version` del commit; si no, falla y no sube nada.
+
+### 6. Smoke install
+
+En venv limpio, instalar desde el wheel publicado:
+
+```bash
+python3.12 -m venv /tmp/matriz-smoke
+/tmp/matriz-smoke/bin/pip install \
+  https://github.com/sebadlf/matriz-client/releases/download/vX.Y.Z/matriz_client-X.Y.Z-py3-none-any.whl
+/tmp/matriz-smoke/bin/python -c "import matriz_client; print(matriz_client.MarketDataSnapshot.empty())"
+```
+
+## Verificación
+
+- [ ] GitHub Release `vX.Y.Z` listado con dos artefactos (`.whl` + `.tar.gz`).
+- [ ] Smoke install funciona en venv limpio.
+- [ ] Linear ticket cerrado.
+
+## Rollback
+
+Los GitHub Releases se pueden borrar (UI o `gh release delete vX.Y.Z`). El tag se borra con `git push origin :refs/tags/vX.Y.Z` y `git tag -d vX.Y.Z` localmente. Como el wheel ya pudo haberse instalado por terceros, lo recomendable es publicar `vX.Y.Z+1` con el fix en lugar de revertir.
+
+## Historial
+
+| Fecha | Quién | Notas |
+|-------|-------|-------|
+| 2026-04-17 | Sebastián | v0.2.0 — cierre del ciclo safe-access (BEC-26..30). |


### PR DESCRIPTION
## Summary

- **`CLAUDE.md`** — el paso 2 del Workflow deja de ser "consultar si aplica" y pasa a ser consulta obligatoria del vault. Se agrega **paso 7 "Cierre del ticket — actualizar el vault"** con checklist explícito de qué nota escribir y cuándo (ADR / runbook / domain note / daily log), más la regla "cero documentación silenciosa": si nada material aplica, igual va una línea en el daily log con la justificación.
- **Aplicación retroactiva al ciclo BEC-26..30** (migración safe-access) que cerró sin documentación:
  - `decisions/ADR-002 — Safe-access dataclasses sobre Pydantic.md`
  - `domain/Wire format y keys opcionales.md`
  - `runbooks/Cortar un release.md`
  - `daily-logs/2026-04-17.md`
  - `projects/matriz-client/README.md` actualizado con nuevas notas y estado actual (v0.2.0).

No es un ticket de Linear — es un cambio de meta-proceso para que futuras sesiones no requieran que el usuario pida la documentación.

## Test plan

- [x] CLAUDE.md compila como Markdown plano (sin secciones rotas).
- [x] Notas del vault siguen los templates en `_templates/`.
- [x] CI pasa lint + format + tests + pyright (no cambia código fuente, debería ser verde).

🤖 Generated with [Claude Code](https://claude.com/claude-code)