### PR TITLE
fix: type MarketDataSnapshot.CL as MarketDataEntryValue (#102)

### DIFF
--- a/matriz_client/models.py
+++ b/matriz_client/models.py
@@ -271,8 +271,10 @@ class MarketDataSnapshot(_SafeModel):
     LA: MarketDataEntryValue = field(default_factory=MarketDataEntryValue.empty)
     SE: MarketDataEntryValue = field(default_factory=MarketDataEntryValue.empty)
     OI: MarketDataEntryValue = field(default_factory=MarketDataEntryValue.empty)
+    # CL viene como objeto {price, size, date} en la wire format (§8.1),
+    # igual que LA/SE/OI. OP en cambio es escalar. Ver issue #102.
+    CL: MarketDataEntryValue = field(default_factory=MarketDataEntryValue.empty)
     OP: float | None = None
-    CL: float | None = None
     HI: float | None = None
     LO: float | None = None
     TV: float | None = None

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -154,6 +154,7 @@ def test_market_data_snapshot_from_spec_example() -> None:
             {"price": 180.35, "size": 1000},
         ],
         "OP": 180.35,
+        "CL": {"price": 180.35, "size": None, "date": 1669852800000},
         "BI": [
             {"price": 179.75, "size": 275},
             {"price": 178.95, "size": 514},
@@ -164,6 +165,28 @@ def test_market_data_snapshot_from_spec_example() -> None:
     assert parsed.BI[0].price == 179.75
     assert parsed.SE.size is None
     assert parsed.SE.price == 180.3
+    assert parsed.CL.price == 180.35
+    assert parsed.CL.date == 1669852800000
+
+
+def test_market_data_snapshot_close_is_entry_value_not_scalar() -> None:
+    """Regression: CL viene como objeto {price, size, date}, no como float (issue #102)."""
+    parsed = MarketDataSnapshot.from_api(
+        {"CL": {"price": 20090.0, "size": None, "date": 1777420800000}}
+    )
+    assert isinstance(parsed.CL, MarketDataEntryValue)
+    assert parsed.CL.price == 20090.0
+    assert parsed.CL.size is None
+    assert parsed.CL.date == 1777420800000
+
+
+def test_market_data_snapshot_close_missing_returns_empty_entry() -> None:
+    """Safe-access: si CL no viene, devuelve un MarketDataEntryValue vacío, no None."""
+    parsed = MarketDataSnapshot.from_api({"OP": 180.0})
+    assert isinstance(parsed.CL, MarketDataEntryValue)
+    assert parsed.CL.price is None
+    assert parsed.CL.size is None
+    assert parsed.CL.date is None
 
 
 def test_market_data_snapshot_accepts_empty_payload() -> None:


### PR DESCRIPTION
## Summary

Fix bug en `MarketDataSnapshot.CL`: la API Primary v1.21 lo devuelve como objeto `{price, size, date}` (igual que `LA`/`SE`/`OI`), pero el modelo lo declaraba como `float | None`. Eso rompía la garantía de safe-access dataclasses — `market_data.CL.price` levantaba `AttributeError` porque el campo quedaba como `dict` crudo.

- `matriz_client/models.py`: `CL` pasa a ser `MarketDataEntryValue` con `default_factory=MarketDataEntryValue.empty`.
- `tests/test_models.py`: el `from_spec_example` ahora incluye `CL`, y se agregan dos regression tests (CL como objeto, CL ausente).

## Why

La spec oficial (`primary_api_llm.md` §8.1, ejemplo de respuesta) ya muestra `CL` como objeto. Verificado también contra runtime real (sandbox `bbsa.matrizoms.com.ar`, símbolo `MERV - XMEV - AAPL - 24HS`):

```
CL=MarketDataEntryValue(price=20090, size=None, date=1777420800000)
```

## Breaking change

Técnicamente sí — pero en la práctica el campo **nunca** funcionó como `float` en runtime; cualquier código que hiciera `md.CL > 100` o `md.CL * 1.05` ya estaba roto. Ahora `md.CL.price` resuelve correctamente, y `md.CL` por sí solo deja de ser comparable a un número.

## Test plan

- [x] `uv run ruff check . && uv run ruff format --check .`
- [x] `uv run pytest` (71 passed)
- [x] `uv run pyright` (0 errors)
- [x] `uv run python main.py` contra la API real → `CL` viene como `MarketDataEntryValue`, no dict.

Closes #102

Made with [Cursor](https://cursor.com)