### PR TITLE
chore: bump matriz_client to 0.2.1 (#102)

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,15 @@ def on_msg(msg: PrimaryWsMessage) -> None:
 
 **Safety guarantee.** Missing keys never raise `KeyError`/`AttributeError`. Lists default to `[]`, nested models to an empty instance, scalars to `None`, dicts to `{}`. Chained access like `snapshot.SE.price` always resolves — the worst case is a final `None`.
 
+## Migrating from 0.2.0 to 0.2.1
+
+`MarketDataSnapshot.CL` ahora es `MarketDataEntryValue` en lugar de `float | None`. La wire format de la Primary API siempre devolvió `CL` como objeto `{price, size, date}` (igual que `LA`/`SE`/`OI`), así que el typing previo era incorrecto y el campo quedaba como `dict` crudo, rompiendo la garantía de safe-access. Acceso correcto:
+
+```python
+md = primary.get_market_data("DLR/DIC23")
+print(md.CL.price)   # antes: TypeError / AttributeError sobre el dict crudo
+```
+
 ## Reference
 
 - Full Primary API v1.21 spec: [`primary_api_llm.md`](./primary_api_llm.md)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "matriz-client"
-version = "0.2.0"
+version = "0.2.1"
 description = "Python client for the MATBA ROFEX Primary API v1.21 (REST + WebSocket)."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -97,7 +97,7 @@ wheels = [
 
 [[package]]
 name = "matriz-client"
-version = "0.2.0"
+version = "0.2.1"
 source = { editable = "." }
 dependencies = [
     { name = "python-dotenv" },


### PR DESCRIPTION
## Summary

Patch release con el fix de #102:
- `MarketDataSnapshot.CL` ahora es `MarketDataEntryValue` (la wire format real).
- `pyproject.toml`: `0.2.0` → `0.2.1`.
- `uv.lock` regenerado.
- README: nota de migración 0.2.0 → 0.2.1.

## Test plan

- [x] `uv build` + `twine check dist/*` → PASSED para wheel y sdist.
- [x] `uv run pytest -q` → 71 passed.
- [x] `uv run ruff check . && uv run ruff format --check .`
- [x] `uv run pyright` → 0 errors.

Tras el merge: tag `v0.2.1` para disparar `release.yml`.

Made with [Cursor](https://cursor.com)