### PR TITLE
docs(vault): cierre de v0.2.1 (GH #102)

### DIFF
--- a/matriz-vault/daily-logs/2026-04-30.md
+++ b/matriz-vault/daily-logs/2026-04-30.md
@@ -1,0 +1,40 @@
+---
+date: 2026-04-30
+tags: [daily]
+---
+
+# Daily Log — 2026-04-30
+
+## Foco del día
+- [x] Cerrar bug de typing en `MarketDataSnapshot.CL`
+- [x] Publicar `v0.2.1`
+
+## Lo que hice
+
+- **GH #102 / PR #103**: detecté el bug corriendo `main.py` contra el sandbox `bbsa.matrizoms.com.ar` con el símbolo `MERV - XMEV - AAPL - 24HS`. El campo `CL` venía como `dict` crudo (`{'price': 20090, 'size': None, 'date': 1777420800000}`) en vez de `MarketDataEntryValue`. El typing en `models.py` lo declaraba como `float | None` — discordante con la spec (`primary_api_llm.md` §8.1, línea 761) que ya muestra `CL` como objeto.
+- Cambié el field a `CL: MarketDataEntryValue = field(default_factory=MarketDataEntryValue.empty)`. El `_convert()` genérico ya hacía el resto.
+- Agregué tres tests: `from_spec_example` ahora cubre `CL`, más dos regression tests (CL como objeto, CL ausente).
+- **PR #104 / v0.2.1**: bump siguiendo el runbook [[Cortar un release]]. `uv build` + `twine check` PASSED, CI verde, tag pusheado, workflow `release.yml` corriendo, artefactos `.whl` + `.tar.gz` publicados, smoke install OK desde `/tmp/matriz-smoke`.
+
+## Aprendizajes
+
+- **Wire format ≠ typing si nadie lo testea**. El test `test_market_data_snapshot_from_spec_example` no incluía `CL`, así que el bug pasó tres releases. Lección: cuando un modelo tiene un set conocido de keys (como las entries de market data), el "spec example" debería cubrirlas todas, no un subset cómodo.
+- **Bugs de typing pueden quedar latentes**. `CL` típicamente venía `null` para los símbolos que probaba antes; recién apareció con un símbolo que sí tenía cierre del día anterior. Vale la pena tener un set de símbolos "ricos" (con OP/CL/SE poblados) en la suite de smoke testing manual.
+- **El flow del CLAUDE.md soporta tickets de GitHub también, no solo Linear**. Adapté el branch format a `sebadlf-gh-102-fix-cl-typing` y mantuve el resto idéntico — `Closes #102` en el PR cierra el issue automáticamente.
+
+## Notas creadas/actualizadas
+
+- [[Wire format y keys opcionales]] — agregué sección "Cuidado: shape no obvio" con el caso `CL` y un checklist de auditoría rápida.
+- [[Cortar un release]] — actualizado historial con la entrada de `v0.2.1`.
+
+## Notas para mañana
+
+- Considerar auditar `HI`, `LO`, `IV`, `EV`, `NV`, `ACP` con la misma metodología (símbolo activo + comparar con spec). Hoy no lo hice porque no tenía evidencia empírica del shape real, pero es deuda técnica.
+- Mirar si vale la pena agregar un test que recorra todo el ejemplo de respuesta de la spec y verifique cada campo declarado en el modelo.
+
+## Referencias
+
+- GH issue: [sebadlf/matriz-client#102](https://github.com/sebadlf/matriz-client/issues/102)
+- Fix PR: [#103](https://github.com/sebadlf/matriz-client/pull/103) (squash en `2596188`)
+- Bump PR: [#104](https://github.com/sebadlf/matriz-client/pull/104) (squash en `549ee30`)
+- Release: [v0.2.1](https://github.com/sebadlf/matriz-client/releases/tag/v0.2.1)

--- a/matriz-vault/projects/matriz-client/domain/Wire format y keys opcionales.md
+++ b/matriz-vault/projects/matriz-client/domain/Wire format y keys opcionales.md
@@ -48,3 +48,22 @@ Esto motivó [[ADR-002 — Safe-access dataclasses sobre Pydantic]]. El cliente 
 1. Declararlo en el `@dataclass` del modelo correspondiente (`matriz_client/models.py`) con su tipo y default seguro (`None` para escalar, `field(default_factory=list/dict)` para colecciones, `field(default_factory=NestedModel.empty)` para anidado).
 2. No hace falta tocar `from_api` — el mixin lo descubre vía `get_type_hints`.
 3. Test en `tests/test_models.py`: payload presente y payload sin la key.
+
+## Cuidado: shape no obvio (ej. `CL` como objeto, no escalar)
+
+Algunas keys que el sentido común sugiere como escalares vienen como sub-objetos `{price, size, date}`. Caso de referencia (issue [#102](https://github.com/sebadlf/matriz-client/issues/102), fix en `v0.2.1`):
+
+- `OP` (Open) viene como **número plano**: `"OP": 180.35`.
+- `CL` (Close) viene como **objeto**: `"CL": {"price": 180.35, "size": null, "date": 1669852800000}` — igual que `LA`/`SE`/`OI`.
+
+La spec lo muestra así desde siempre (`primary_api_llm.md` §8.1, ejemplo de respuesta), pero el modelo declaraba `CL: float | None`, lo que rompía el safe-access (`md.CL` quedaba como `dict` crudo y `md.CL.price` levantaba `AttributeError`).
+
+### Checklist al modelar una key nueva
+
+1. **Mirar el ejemplo de respuesta de la spec** antes de elegir el tipo. Si la key aparece como objeto (`{price, size, date}` o cualquier otro), el tipo es un nested `_SafeModel`, no un escalar.
+2. **Verificar contra runtime real** con un símbolo que tenga ese campo poblado. Para market data: símbolos con cierre del día anterior + último operado + ajuste son los más completos (ej. acciones líquidas en `MERV - XMEV - * - 24HS`).
+3. **Cubrir el campo en el `from_spec_example` test** del modelo. Si el test no lo incluye, el bug pasa silencioso porque los nested models toleran ausencia.
+
+### Pendiente de auditar
+
+`HI`, `LO`, `IV`, `EV`, `NV`, `ACP` están declarados como `float | None` en `MarketDataSnapshot` pero no aparecen en el ejemplo de la spec. Antes de tocarlos hay que conseguir un payload real con esos campos para confirmar el shape.

--- a/matriz-vault/projects/matriz-client/runbooks/Cortar un release.md
+++ b/matriz-vault/projects/matriz-client/runbooks/Cortar un release.md
@@ -84,3 +84,4 @@ Los GitHub Releases se pueden borrar (UI o `gh release delete vX.Y.Z`). El tag s
 | Fecha | Quién | Notas |
 |-------|-------|-------|
 | 2026-04-17 | Sebastián | v0.2.0 — cierre del ciclo safe-access (BEC-26..30). |
+| 2026-04-30 | Sebastián | v0.2.1 — patch del typing de `MarketDataSnapshot.CL` (GH #102). Smoke install OK. |


### PR DESCRIPTION
## Summary

Documentación del cierre del ticket [#102](https://github.com/sebadlf/matriz-client/issues/102) y del release `v0.2.1`, según el flow del `CLAUDE.md`.

- `daily-logs/2026-04-30.md`: cierre del ticket de typing y bump.
- `domain/Wire format y keys opcionales.md`: nueva sección "Cuidado: shape no obvio" con el caso `CL` y un checklist de auditoría para evitar el mismo bug en `HI`/`LO`/`IV`/`EV`/`NV`/`ACP`.
- `runbooks/Cortar un release.md`: historial actualizado con `v0.2.1`.

No agrego ADR — es fix de bug, no decisión arquitectónica nueva.

## Test plan

- [x] Markdown renderiza limpio (revisado en preview).
- [x] Links internos al estilo `[[wikilink]]` consistentes con el vault existente.

Made with [Cursor](https://cursor.com)